### PR TITLE
Mise à jour de l'URL du fond de carte "photographies aériennes"

### DIFF
--- a/src/assets/styles/base-vecto.json
+++ b/src/assets/styles/base-vecto.json
@@ -31,7 +31,7 @@
     "photographies-aeriennes": {
       "type": "raster",
       "tiles": [
-        "https://tiles.geo.api.gouv.fr/photographies-aeriennes/tiles/{z}/{x}/{y}"
+        "https://wxs.ign.fr/essentiels/geoportail/wmts?layer=ORTHOIMAGERY.ORTHOPHOTOS&style=normal&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}"
       ],
       "tileSize": 256,
       "attribution": "Images aériennes © IGN",


### PR DESCRIPTION
La précédente URL était l'URL d'un proxy qui masquait les problèmes de performance et de disponibilité du Géoportail IGN.
Il apportait aussi une mise en cache qui pouvait durer plusieurs mois, et l'HTTP/2.

Nous avons finalement décidé de le dé-commissionner, et encourageons donc très rapidement ses utilisateurs à basculer sur le flux officiel de l'IGN.

Cf etalab/adresse.data.gouv.fr#863