### PR TITLE
Export Certipaq en CSV

### DIFF
--- a/src/components/Features/ExportModal.vue
+++ b/src/components/Features/ExportModal.vue
@@ -15,7 +15,7 @@
       <ul class="fr-btns-group fr-btns-group--icon-left">
         <li>
           <button class="fr-btn fr-icon-table-line fr-btn--secondary" @click="ocExport">
-              {{ strategy.name }}&nbsp;<small>(<code :aria-label="strategy.name">{{ strategy.extension }}</code>)</small>
+              {{ strategy.name }}&nbsp;<small>(<code :aria-label="strategy.name">.{{ strategy.extension }}</code>)</small>
           </button>
         </li>
         <li>
@@ -39,7 +39,6 @@
 
 <script setup>
 import { computed, toRaw } from 'vue'
-import { writeFile } from 'xlsx'
 import { fromId } from './ExportStrategies/index.js'
 
 import Modal from '@/components/Modal.vue'
@@ -73,11 +72,16 @@ function geojsonExport() {
 }
 
 function ocExport () {
-  const workbook = strategy({
+  const strategy = fromId(organismeCertificateurId.value)
+  const data = strategy({
     featureCollection: props.collection,
     operator: props.operator
   })
 
-  return writeFile(workbook, `${filenameBase.value}.xlsx`, { bookType : 'xlsx' })
+  const link = document.createElement('a')
+  link.href = URL.createObjectURL(data)
+  link.download = `${filenameBase.value}.${strategy.extension}`
+  link.mime = strategy.mime
+  link.click()
 }
 </script>

--- a/src/components/Features/ExportModal.vue
+++ b/src/components/Features/ExportModal.vue
@@ -15,7 +15,7 @@
       <ul class="fr-btns-group fr-btns-group--icon-left">
         <li>
           <button class="fr-btn fr-icon-table-line fr-btn--secondary" @click="ocExport">
-              {{ strategy.name }}&nbsp;<small>(<code :aria-label="strategy.name">.{{ strategy.extension }}</code>)</small>
+              {{ strategy.label }}&nbsp;<small>(<code :aria-label="strategy.label">.{{ strategy.extension }}</code>)</small>
           </button>
         </li>
         <li>

--- a/src/components/Features/ExportModal.vue
+++ b/src/components/Features/ExportModal.vue
@@ -14,8 +14,8 @@
     <template #footer>
       <ul class="fr-btns-group fr-btns-group--icon-left">
         <li>
-          <button class="fr-btn fr-icon-table-line fr-btn--secondary" @click="excelExport({ strategy })">
-            Excel&nbsp;<small>(<code aria-label="Extension de fichier .xlsx">.xlsx</code>)</small>
+          <button class="fr-btn fr-icon-table-line fr-btn--secondary" @click="ocExport">
+              {{ strategy.name }}&nbsp;<small>(<code :aria-label="strategy.name">{{ strategy.extension }}</code>)</small>
           </button>
         </li>
         <li>
@@ -58,6 +58,7 @@ const props = defineProps({
 const numeroBio = computed(() => props.operator.numeroBio)
 const organismeCertificateurId = computed(() => props.operator.organismeCertificateur.id)
 const filenameBase = computed(() => `parcellaire-operateur-${props.operator.numeroBio}`)
+const strategy = computed(() => fromId(organismeCertificateurId.value))
 
 function geojsonExport() {
   const blob = new Blob(
@@ -71,9 +72,7 @@ function geojsonExport() {
   link.click()
 }
 
-function excelExport () {
-  const strategy = fromId(organismeCertificateurId.value)
-
+function ocExport () {
   const workbook = strategy({
     featureCollection: props.collection,
     operator: props.operator

--- a/src/components/Features/ExportStrategies/certipaq.js
+++ b/src/components/Features/ExportStrategies/certipaq.js
@@ -151,7 +151,7 @@ const Certipaq = ({ featureCollection, operator }) => {
   return new Blob([sheet_to_csv(sheet, { FS: ';' })])
 }
 
-Certipaq.label = "Certipaq"
+Certipaq.label = "Tableur"
 Certipaq.extension = "csv"
 Certipaq.mimetype = "text/csv"
 

--- a/src/components/Features/ExportStrategies/certipaq.js
+++ b/src/components/Features/ExportStrategies/certipaq.js
@@ -2,11 +2,10 @@ import { utils } from 'xlsx'
 import { fromCodePac } from '@agencebio/rosetta-cultures'
 import { surface, GROUPE_CULTURE, GROUPE_NIVEAU_CONVERSION, getFeatureGroups } from '@/components/Features/index.js'
 
-const { book_new, aoa_to_sheet, sheet_add_aoa, book_append_sheet } = utils
+const { aoa_to_sheet, sheet_add_aoa, sheet_to_csv } = utils
 const { decode_range: R } = utils
 
 const Certipaq = ({ featureCollection, operator }) => {
-  const workbook = book_new()
   const notification = operator.notifications.find(({ status }) => status === 'ACTIVE') ?? operator.notifications.at(0)
 
   // First sheet
@@ -149,10 +148,7 @@ const Certipaq = ({ featureCollection, operator }) => {
       .forEach(col => Object.assign(sheet[`${col}${9 + index}`], { t: 'n', z: '0.00' }))
   })
 
-  // First sheet: finalize
-  book_append_sheet(workbook, sheet, 'Parcellaire bio');
-
-  return workbook
+  return new Blob([sheet_to_csv(sheet, { FS: ';' })])
 }
 
 Certipaq.label = "Certipaq"

--- a/src/components/Features/ExportStrategies/certipaq.js
+++ b/src/components/Features/ExportStrategies/certipaq.js
@@ -5,7 +5,7 @@ import { surface, GROUPE_CULTURE, GROUPE_NIVEAU_CONVERSION, getFeatureGroups } f
 const { book_new, aoa_to_sheet, sheet_add_aoa, book_append_sheet } = utils
 const { decode_range: R } = utils
 
-export default ({ featureCollection, operator }) => {
+const Certipaq = ({ featureCollection, operator }) => {
   const workbook = book_new()
   const notification = operator.notifications.find(({ status }) => status === 'ACTIVE') ?? operator.notifications.at(0)
 
@@ -154,3 +154,9 @@ export default ({ featureCollection, operator }) => {
 
   return workbook
 }
+
+Certipaq.label = "Certipaq"
+Certipaq.extension = "csv"
+Certipaq.mimetype = "text/csv"
+
+export default Certipaq;

--- a/src/components/Features/ExportStrategies/default.js
+++ b/src/components/Features/ExportStrategies/default.js
@@ -5,7 +5,7 @@ import { surface, inHa } from '@/components/Features/index.js'
 const { book_new, aoa_to_sheet, sheet_add_aoa, book_append_sheet } = utils
 const { decode_range: R } = utils
 
-export default ({ featureCollection, operator }) => {
+const Default = ({ featureCollection, operator }) => {
   const workbook = book_new()
 
   // First sheet
@@ -74,3 +74,9 @@ export default ({ featureCollection, operator }) => {
 
   return workbook
 }
+
+Default.label = 'Excel'
+Default.extension = 'xlsx'
+Default.mimeType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+export default Default;

--- a/src/components/Features/ExportStrategies/default.js
+++ b/src/components/Features/ExportStrategies/default.js
@@ -1,4 +1,4 @@
-import { utils } from 'xlsx'
+import { utils, write } from 'xlsx'
 import { fromCodePac } from '@agencebio/rosetta-cultures'
 import { surface, inHa } from '@/components/Features/index.js'
 
@@ -72,7 +72,7 @@ const Default = ({ featureCollection, operator }) => {
   // First sheet: finalize
   book_append_sheet(workbook, sheet, 'Parcellaire bio');
 
-  return workbook
+  return new Blob([write(workbook, { bookType: 'xlsx', type: 'array' })], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
 }
 
 Default.label = 'Excel'


### PR DESCRIPTION
Ajoute les propriétés suivantes aux stratégies d'export :
* `label`
* `extension`
* `mime`

Les stratégies doivent dorénavant directement renvoyer un blob de données à télécharger.
La stratégie `Certipaq` renvoie maintenant du CSV.