### PR TITLE
Fix et mise à jour de la config ESLint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,11 +31,13 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
+        "@rushstack/eslint-patch": "^1.2.0",
         "@sentry/vite-plugin": "^0.7.2",
         "@testing-library/vue": "^6.4.2",
         "@typescript-eslint/eslint-plugin": "^5.45.1",
         "@typescript-eslint/parser": "^5.45.1",
         "@vitejs/plugin-vue": "^4.0.0",
+        "@vue/eslint-config-typescript": "^11.0.3",
         "autoprefixer": "^10.4.2",
         "eslint": "^8.6.0",
         "eslint-plugin-vue": "^9.6.0",
@@ -1498,6 +1500,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rushstack/eslint-patch": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
+      "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==",
+      "dev": true
+    },
     "node_modules/@sentry-internal/tracing": {
       "version": "7.49.0",
       "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.49.0.tgz",
@@ -2296,6 +2304,30 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
       "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
+    },
+    "node_modules/@vue/eslint-config-typescript": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-11.0.3.tgz",
+      "integrity": "sha512-dkt6W0PX6H/4Xuxg/BlFj5xHvksjpSlVjtkQCpaYJBIEuKj2hOVU7r+TIe+ysCwRYFz/lGqvklntRkCAibsbPw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.59.1",
+        "@typescript-eslint/parser": "^5.59.1",
+        "vue-eslint-parser": "^9.1.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0",
+        "eslint-plugin-vue": "^9.0.0",
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vue/reactivity": {
       "version": "3.2.47",

--- a/package.json
+++ b/package.json
@@ -43,12 +43,10 @@
   "devDependencies": {
     "@sentry/vite-plugin": "^0.7.2",
     "@testing-library/vue": "^6.4.2",
-    "@typescript-eslint/eslint-plugin": "^5.45.1",
-    "@typescript-eslint/parser": "^5.45.1",
     "@vitejs/plugin-vue": "^4.0.0",
+    "@vue/eslint-config-typescript": "^11.0.3",
     "autoprefixer": "^10.4.2",
     "eslint": "^8.6.0",
-    "eslint-plugin-vue": "^9.6.0",
     "postcss-preset-env": "^8.3.2",
     "typescript": "^5.0.4",
     "vite": "^4.2.1",
@@ -61,12 +59,9 @@
       "node": true
     },
     "extends": [
-      "plugin:vue/base",
+      "plugin:vue/vue3-essential",
       "eslint:recommended",
-      "plugin:@typescript-eslint/recommended"
-    ],
-    "plugins": [
-      "@typescript-eslint"
+      "@vue/eslint-config-typescript/recommended"
     ],
     "rules": {
       "no-unused-vars": "warn",
@@ -75,7 +70,6 @@
       "vue/no-multiple-template-root": "off",
       "vue/script-setup-uses-vars": "error"
     },
-    "parser": "@typescript-eslint/parser",
     "parserOptions": {
       "ecmaVersion": "latest",
       "sourceType": "module"

--- a/src/components/Certification/EngagementDateModal.vue
+++ b/src/components/Certification/EngagementDateModal.vue
@@ -36,7 +36,7 @@ import { useFeaturesStore } from '@/stores/features.js'
 
 import Modal from '@/components/Modal.vue'
 
-const props = defineProps({ })
+defineProps({ })
 const emit = defineEmits(['submit'])
 
 const store = useFeaturesStore()

--- a/src/components/Certification/EngagementLevelModal.vue
+++ b/src/components/Certification/EngagementLevelModal.vue
@@ -41,7 +41,7 @@ import { useFeaturesStore } from '@/stores/features.js'
 
 import Modal from '@/components/Modal.vue'
 
-const props = defineProps({ })
+defineProps({ })
 const emit = defineEmits(['submit'])
 
 const store = useFeaturesStore()

--- a/src/components/Certification/Summary.vue
+++ b/src/components/Certification/Summary.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fr-alert fr-alert--warning fr-mb-3w" v-if="hasFailures">
-    <p v-for="([ruleId, result]) in validationRulesWithFailures">
+    <p v-for="([ruleId, result]) in validationRulesWithFailures" :key="ruleId">
       {{ ruleId === 'NOT_EMPTY' ? `Il manque un type de culture dans ${result.failures} parcelles.` : '' }}
       {{ ruleId === 'ENGAGEMENT_DATE' ? `Il manque une date d'engagement et/ou un niveau de conversion dans ${result.failures} parcelles.` : '' }}
     </p>
@@ -49,7 +49,7 @@ const props = defineProps({
 const sendOffModal = ref(false)
 const validationResult = computed(() => applyValidationRules(props.validationRules.rules, ...props.features.features))
 const hasFailures = computed(() => Boolean(validationResult.value.failures))
-const validationRulesWithFailures = computed(() => Object.entries(validationResult.value.rules).filter(([ruleId, { failures }]) => failures))
+const validationRulesWithFailures = computed(() => Object.entries(validationResult.value.rules).filter(([, { failures }]) => failures))
 const isComplete = computed(() => hasFailures.value === false)
 const isAudited = computed(() => isCertificationImmutable(props.record.certification_state))
 

--- a/src/components/Features/CultureSelector.vue
+++ b/src/components/Features/CultureSelector.vue
@@ -11,7 +11,7 @@ import '@algolia/autocomplete-theme-classic';
 
 const autocompleteRef = ref(null)
 
-const { modelValue } = defineProps(['modelValue'])
+const props = defineProps(['modelValue'])
 const emit = defineEmits(['update:modelValue'])
 
 onMounted(() => {
@@ -44,7 +44,7 @@ onMounted(() => {
     renderer: { createElement: h, Fragment, render }
   })
 
-  setQuery(codesPac.find(([code,]) => code === modelValue)?.[1] || '')
+  setQuery(codesPac.find(([code,]) => code === props.modelValue)?.[1] || '')
 })
 </script>
 

--- a/src/components/Features/ExportModal.vue
+++ b/src/components/Features/ExportModal.vue
@@ -65,11 +65,10 @@ const props = defineProps({
   }
 })
 
-const numeroBio = computed(() => props.operator.numeroBio)
 const organismeCertificateurId = computed(() => props.operator.organismeCertificateur.id)
 const filenameBase = computed(() => `parcellaire-operateur-${props.operator.numeroBio}`)
 const exporter = computed(function () {
-  let exporterClass = fromId(organismeCertificateurId.value)
+  const exporterClass = fromId(organismeCertificateurId.value)
   return new exporterClass({
     featureCollection: props.collection,
     operator: props.operator

--- a/src/components/Features/ExportStrategies/CertipaqExporter.js
+++ b/src/components/Features/ExportStrategies/CertipaqExporter.js
@@ -175,7 +175,7 @@ class CertipaqExporter extends BaseExporter {
     // Remove first 5 rows, keep first columns A to J
     sheet = sheet.slice(5).map(row => row.slice(0, 10))
     sheet = json_to_sheet(sheet)
-    let data = sheet_to_csv(sheet, { FS: '\t' })
+    const data = sheet_to_csv(sheet, { FS: '\t' })
 
     return navigator.clipboard.writeText(data)
   }

--- a/src/components/Features/MassActionsSelector.vue
+++ b/src/components/Features/MassActionsSelector.vue
@@ -6,7 +6,7 @@
       </button>
       <div :class="['fr-collapse', 'fr-translate__menu', 'fr-menu', isMenuOpen && 'fr-collapse--expanded']" id="mass-actions__actions" data-fr-js-collapse="true" style="--collapse-max-height: none; --collapse: -148px">
         <ul class="fr-menu__list">
-          <li class="w-full" v-for="({ label, component }) in actions">
+          <li class="w-full" v-for="({ label, component }) in actions" :key="label">
             <button class="fr-btn fr-btn--tertiary-no-outline w-full" type="button" @click="openModalWithComponent(component)">
               {{ label }}
             </button>
@@ -25,7 +25,7 @@
 import { ref } from 'vue'
 import { onClickOutside } from '@vueuse/core'
 
-const props = defineProps({
+defineProps({
   label: {
     type: String,
     required: true

--- a/src/components/Features/Table.vue
+++ b/src/components/Features/Table.vue
@@ -108,7 +108,6 @@ const editedFeatureId = ref(null)
 const editedFeature = computed(() => editedFeatureId.value ? getFeatureById(props.features.features, editedFeatureId.value) : null)
 
 const userGroupingChoice = ref('CULTURE')
-const handleUserGroupingChoice = ($event) => userGroupingChoice.value = $event.target.value
 
 // hence, feature groups
 const featureGroups = computed(() => getFeatureGroups(props.features, userGroupingChoice.value))

--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script setup>
-import { computed } from '@vue/reactivity'
+import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 const route = useRoute()

--- a/src/components/Map/GeojsonLayer.vue
+++ b/src/components/Map/GeojsonLayer.vue
@@ -1,5 +1,3 @@
-<template></template>
-
 <script setup>
 import { inject, watch } from 'vue'
 

--- a/src/components/Map/Legend.vue
+++ b/src/components/Map/Legend.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup>
-const props = defineProps(['position'])
+defineProps(['position'])
 </script>
 
 <style scoped>

--- a/src/components/Map/MapContainer.vue
+++ b/src/components/Map/MapContainer.vue
@@ -25,7 +25,9 @@ const props = defineProps({
   },
   options: {
     type: Object,
-    default: {}
+    default() {
+      return {}
+    }
   },
   style: {
     type: [Object, String],

--- a/src/components/Map/Popup.vue
+++ b/src/components/Map/Popup.vue
@@ -16,7 +16,9 @@ const popupRef = ref(null)
 const props = defineProps({
   lnglat: {
     type: Array,
-    default: [0, 0],
+    default() {
+      return [0, 0]
+    }
   },
   maxWidth: {
     type: String,
@@ -24,7 +26,9 @@ const props = defineProps({
   },
   offset: {
     type: Array,
-    default: [0, -15]
+    default() {
+      return [0, -15]
+    }
   },
 })
 

--- a/src/components/Operator/CultureTypeModal.vue
+++ b/src/components/Operator/CultureTypeModal.vue
@@ -35,7 +35,7 @@ import { useFeaturesStore } from '@/stores/features.js'
 import Modal from '@/components/Modal.vue'
 import CultureSelector from "@/components/Features/CultureSelector.vue";
 
-const props = defineProps({ })
+defineProps({ })
 const emit = defineEmits(['submit'])
 
 const store = useFeaturesStore()

--- a/src/components/Operator/HistoryModal.vue
+++ b/src/components/Operator/HistoryModal.vue
@@ -41,7 +41,7 @@ import { ddmmmmyyyy } from '@/components/dates.js'
 import Modal from '@/components/Modal.vue'
 import CertificationState from '@/components/Certification/State.vue'
 
-const props = defineProps({
+defineProps({
   operator: {
     type: Object,
     required: true

--- a/src/components/OperatorSetup/Geofolia.vue
+++ b/src/components/OperatorSetup/Geofolia.vue
@@ -32,10 +32,8 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import axios from 'axios'
-import { statsPush } from '@/stats.js'
-import store from '../../store.js'
 
 const { VUE_APP_API_ENDPOINT } = import.meta.env
 

--- a/src/components/OperatorSetup/MesParcelles.vue
+++ b/src/components/OperatorSetup/MesParcelles.vue
@@ -41,10 +41,8 @@
 </template>
 
 <script setup>
-import { ref, readonly } from 'vue'
+import { readonly, ref } from 'vue'
 import axios from 'axios'
-import { statsPush } from '@/stats.js'
-import store from '../../store.js'
 
 const { VUE_APP_API_ENDPOINT } = import.meta.env
 

--- a/src/components/OperatorSetup/Telepac.vue
+++ b/src/components/OperatorSetup/Telepac.vue
@@ -86,7 +86,7 @@
 </template>
 
 <script setup>
-import { ref, computed, readonly } from 'vue'
+import { ref } from 'vue'
 import { convertShapefileArchiveToGeoJSON } from '@/cartobio-api.js'
 import { useTélépac } from '@/referentiels/pac.js'
 
@@ -95,16 +95,6 @@ const télépac = useTélépac()
 
 const fileInput = ref(null)
 const source = 'telepac'
-
-const helpSteps = readonly([
-  { label: 'Je me connecte à Télépac' },
-  { label: `Téléprocédure Dossier PAC ${télépac.campagne.value}` },
-  { label: 'Onglet Import/export' },
-  { label: 'Téléchargement du fichier' },
-])
-
-const currentStepIndex = ref(0)
-const nextStepIndex = computed(() => currentStepIndex.value < helpSteps.length ? currentStepIndex.value + 1 : currentStepIndex.value)
 
 async function handleFileUpload () {
   const [archive] = fileInput.value.files

--- a/src/pages/exploitation/login.vue
+++ b/src/pages/exploitation/login.vue
@@ -89,7 +89,7 @@ const cleanedInput = computed(() => userLogin.value.trim())
 const cleanedInputWithoutSpaces = computed(() => userLogin.value.replace(/ /g, ''))
 
 const isLoading = ref(false)
-let candidateUsers = ref([])
+const candidateUsers = ref([])
 
 const LOGIN_TYPES = [
   { id: 'name', label: "nom" },

--- a/src/pages/exploitation/setup.vue
+++ b/src/pages/exploitation/setup.vue
@@ -97,7 +97,7 @@ function onSuccess ({ geojson }) {
   currentStepIndex.value += 1
 }
 
-function onError (error) {
+function onError () {
   statsPush(['trackEvent', 'setup', `import:${importTool.value}`, 'error'])
 }
 </script>


### PR DESCRIPTION
* ajoute `@vue/eslint-config-typescript/recommended` qui étend le précédent `@typescript-eslint/recommended` https://github.com/vuejs/eslint-config-typescript#vueeslint-config-typescriptrecommended
* enlève l'option `parser` (automatiquement configurée à `vue-eslint-parser` qui étend `@typescript-eslint/parser`) https://eslint.vuejs.org/user-guide/#what-is-the-use-the-latest-vue-eslint-parser-error
* enlève les plugins eux aussi inclus `@vue/eslint-config-typescript/recommended`
* ajoute les règles `vue/vue3-essential` comme dans la configuration par défault de `create-vue`
* fix les warnings et les erreurs actuelles