### PR TITLE
Pre upload des versions dans Sentry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,3 +58,20 @@ jobs:
         REMOTE_HOST: ${{ secrets.AGENCEBIO_SSH_HOST }}
         REMOTE_USER: ${{ secrets.AGENCEBIO_SSH_USERNAME }}
         REMOTE_PATH: /var/www/cartobio.agencebio.org/
+
+    - name: Create Sentry production release
+      uses: getsentry/action-release@v1
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: betagouv
+        SENTRY_PROJECT: cartobio-front
+        SENTRY_URL: https://sentry.incubateur.net/
+        SENTRY_LOG_LEVEL: debug
+      with:
+        environment: production
+        # On a pas l'intégration GitHub qui permet que Sentry récupère dans
+        # l'autre sens les commits liés à la release, donc on skip
+        set_commits: skip
+        # Le tag de la release est le nom du tag git
+        version: ${{ github.ref }}
+        sourcemaps: dist/assets/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         VUE_APP_PRELOADED_CAMPAGNE_PAC: 2021
         VUE_APP_ENVIRONMENT: staging
         VUE_APP_SENTRY_DSN: ${{ secrets.VUE_APP_SENTRY_DSN }}
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        VITE_GIT_COMMIT_SHA: ${{ github.sha }}
 
     - run: npm clean-install-test
     - run: |
@@ -59,16 +59,20 @@ jobs:
     - id: version
       run: echo v=$(node -p "require('./package.json').version") >> "$GITHUB_OUTPUT"
 
-    - name: Create Sentry release
+    - name: Create Sentry staging release
       uses: getsentry/action-release@v1
-      continue-on-error: true
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_ORG: betagouv
         SENTRY_PROJECT: cartobio-front
         SENTRY_URL: https://sentry.incubateur.net/
-        SENTRY_LOG_LEVEL: debug
       with:
         environment: staging
         sourcemaps: dist/assets/
-        version: "${{ steps.version.outputs.v }}"
+        # On a pas l'intégration GitHub qui permet que Sentry récupère dans
+        # l'autre sens les commits liés à la release, donc on skip
+        set_commits: skip
+        # Permet d'avoir le nom de la dernière release de prod
+        # dans le nom affiché sur Sentry tout en gardant un
+        # identifiant unique à ce commit
+        version: "${{ steps.version.outputs.v }}-dev-${{ github.sha }}"

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import store from './store.js'
 import { useUserStore } from '@/stores/index.js'
 import { getOperatorParcelles } from './cartobio-api.js'
 import App from './App.vue'
+import { version } from "../package.json"
 
 const { VUE_APP_MATOMO_SITE_ID:siteId = '245', VUE_APP_API_ENDPOINT } = import.meta.env
 const { VUE_APP_SENTRY_DSN } = import.meta.env
@@ -61,11 +62,12 @@ router.isReady().then(() => {
         integrations: [
           new Sentry.BrowserTracing({
             routingInstrumentation: Sentry.vueRouterInstrumentation(router),
-            tracingOrigins: ['localhost', 'cartobio.agencebio.org', 'cartobio-preprod.agencebio.org', /^.+--cartobio-dev.netlify.app$/],
+            tracingOrigins: ['cartobio.agencebio.org', 'cartobio-preprod.agencebio.org', /^.+--cartobio-dev.netlify.app$/],
           }),
         ],
         logErrors: true,
         tracesSampleRate: import.meta.env.PROD ? 0.3 : 1.0,
+        release: import.meta.env.PROD ? version : `${version}-dev-${import.meta.env.VITE_GIT_COMMIT_SHA}`,
       })
     }
     catch (error) {


### PR DESCRIPTION
On a bien le token qui permet d'uploader la version avec les sourcesmaps dans un sens, mais pas l'intégration qui permet de récupérer les commits dans l'autre sens (et on peut pas l'avoir), donc on laisse tomber cette seconde partie :)

Mais surtout j'ai bien synchronisé la version uploadée avec la version dans la config de Sentry au moment du build, donc ça devrait enfin marcher.