### PR TITLE
Maj export/validation pour quand type PAC absent

### DIFF
--- a/src/components/Features/ExportStrategies/BureauVeritasExporter.js
+++ b/src/components/Features/ExportStrategies/BureauVeritasExporter.js
@@ -1,6 +1,12 @@
 import { utils, write } from 'xlsx'
-import { fromCodePac } from '@agencebio/rosetta-cultures'
-import { GROUPE_DATE_ENGAGEMENT, GROUPE_CULTURE, GROUPE_NIVEAU_CONVERSION, featureName, getFeatureGroups } from '@/components/Features/index.js'
+import { fromCodeCpf } from '@agencebio/rosetta-cultures'
+import {
+  featureName,
+  getFeatureGroups,
+  GROUPE_CULTURE,
+  GROUPE_DATE_ENGAGEMENT,
+  GROUPE_NIVEAU_CONVERSION
+} from '@/components/Features/index.js'
 import BaseExporter from "@/components/Features/ExportStrategies/BaseExporter.js";
 
 const { aoa_to_sheet, book_append_sheet, book_new, sheet_add_aoa } = utils
@@ -48,7 +54,7 @@ const getSheet = ({ featureCollection, operator }) => {
   ]
 
   getFeatureGroups(featureCollection, [GROUPE_CULTURE, GROUPE_NIVEAU_CONVERSION, GROUPE_DATE_ENGAGEMENT]).forEach(({ key, surface, features }, index) => {
-    const culture = fromCodePac(key)
+    const culture = fromCodeCpf(key)
 
     sheet_add_aoa(sheet, [
       [

--- a/src/components/Features/ExportStrategies/ControlUnionExporter.js
+++ b/src/components/Features/ExportStrategies/ControlUnionExporter.js
@@ -1,7 +1,7 @@
 import BaseExporter from "@/components/Features/ExportStrategies/BaseExporter.js";
 import { utils, write } from "xlsx";
 import { surface } from "@/components/Features/index.js"
-import { fromCodePac } from "@agencebio/rosetta-cultures"
+import { fromCodeCpf } from "@agencebio/rosetta-cultures"
 
 const getSheet = ({ featureCollection, operator }) => {
   const notification = operator.notifications.find(({ status }) => status === 'ACTIVE') ?? operator.notifications.at(0)
@@ -32,7 +32,7 @@ const getSheet = ({ featureCollection, operator }) => {
 
   utils.sheet_add_aoa(sheet, featureCollection.features.map(({ geometry, properties: props }) => {
     const surfaceHa = surface(geometry) / 10_000
-    const culture = fromCodePac(props.TYPE)
+    const culture = fromCodeCpf(props.CPF)
 
     return [
       '',

--- a/src/components/Features/ExportStrategies/DefaultExporter.js
+++ b/src/components/Features/ExportStrategies/DefaultExporter.js
@@ -1,5 +1,5 @@
 import { utils, write } from 'xlsx'
-import { fromCodePac } from '@agencebio/rosetta-cultures'
+import { fromCodeCpf } from '@agencebio/rosetta-cultures'
 import { surface } from '@/components/Features/index.js'
 import BaseExporter from "@/components/Features/ExportStrategies/BaseExporter.js";
 
@@ -40,10 +40,10 @@ const getSheet = ({ featureCollection, operator }) => {
 
   sheet_add_aoa(sheet, featureCollection.features.map(({ geometry, properties: props, id }) => {
     const [ilotId, parcelleId] = [props.NUMERO_I, props.NUMERO_P]
-    const label = props.TYPE_LIBELLE ?? fromCodePac(props.TYPE)?.libelle_code_cpf
+    const label = props.TYPE_LIBELLE ?? fromCodeCpf(props.CPF)?.libelle_code_cpf
     const surfaceHa = surface(geometry) / 10_000
     const isPac = Boolean(props.PACAGE)
-    const culture = props.TYPE
+    const culture = props.TYPE ?? fromCodeCpf(props.CPF)?.cultures_pac[0]?.code
 
     return [
       id,

--- a/src/components/Features/ExportStrategies/OcaciaExporter.js
+++ b/src/components/Features/ExportStrategies/OcaciaExporter.js
@@ -1,17 +1,16 @@
 import { utils, write } from 'xlsx'
-import { fromCodePac } from '@agencebio/rosetta-cultures'
+import { fromCodeCpf } from '@agencebio/rosetta-cultures'
 import { surface } from '@/components/Features/index.js'
 
 import BaseExporter from "@/components/Features/ExportStrategies/BaseExporter.js";
 
 const { aoa_to_sheet, book_append_sheet, book_new, sheet_to_csv } = utils
-const cultureCpf = (culture, TYPE) => culture?.libelle_code_cpf ?? `[ERREUR] correspondance manquante avec ${TYPE}`
 
-const getSheet = ({ featureCollection, operator }) => {
-  const sheet = aoa_to_sheet(featureCollection.features.map(({ geometry, properties: props, id }) => {
+const getSheet = ({ featureCollection }) => {
+  const sheet = aoa_to_sheet(featureCollection.features.map(({ geometry, properties: props }) => {
     const [ilotId, parcelleId] = [props.NUMERO_I, props.NUMERO_P]
     const surfaceHa = surface(geometry) / 10_000
-    const culture = fromCodePac(props.TYPE)
+    const culture = fromCodeCpf(props.CPF)
 
     return [
       // Commune
@@ -19,7 +18,7 @@ const getSheet = ({ featureCollection, operator }) => {
       // Ilot
       `${ilotId}.${parcelleId}`,
       // Culture
-      cultureCpf(culture, props.TYPE),
+      culture?.libelle_code_cpf ?? `[ERREUR] culture inconnue`,
       // N° Cadastre
       props.cadastre,
       // Variété / infos

--- a/src/referentiels/ab.js
+++ b/src/referentiels/ab.js
@@ -40,20 +40,24 @@ export const RULE_CPF = 'CPF'
 
 const VALIDATION_RULES = {
   [RULE_NOT_EMPTY] (feature) {
-    return Boolean(feature.properties.TYPE)
+    return Boolean(feature.properties.CPF)
   },
   [RULE_CPF] (feature) {
-    return !!feature.properties.CPF && fromCodeCpf(feature.properties.CPF).is_selectable
+    return Boolean(!feature.properties.CPF) || fromCodeCpf(feature.properties.CPF).is_selectable
   },
   [RULE_ENGAGEMENT_DATE] (feature) {
     const { conversion_niveau, engagement_date } = feature.properties
     const conversionLevel = getConversionLevel(conversion_niveau)
 
-    if (conversionLevel.value === LEVEL_UNKNOWN || (isABLevel(conversion_niveau) && conversion_niveau !== LEVEL_AB && !engagement_date)) {
+    if (conversionLevel.value === LEVEL_UNKNOWN) {
       return false
     }
 
-    return true
+    if ([LEVEL_CONVENTIONAL, LEVEL_AB].includes(conversionLevel.value)) {
+      return true
+    }
+
+    return Boolean(engagement_date)
   }
 }
 

--- a/src/referentiels/ab.test.js
+++ b/src/referentiels/ab.test.js
@@ -4,7 +4,7 @@ import { applyValidationRules, OPERATOR_RULES, AUDITOR_RULES } from './ab.js'
 import { useFeaturesStore } from "@/stores/index.js"
 
 describe('applyValidationRules', () => {
-  test('operator requires culture type and cpf', () => {
+  test('operator requires culture cpf', () => {
     const features = [
       { id: 1, properties: { TYPE: 'BTH' }},
       { id: 2, properties: { TYPE: '' }}
@@ -14,15 +14,15 @@ describe('applyValidationRules', () => {
     const result = applyValidationRules(OPERATOR_RULES, ...store.collection.features)
 
     expect(result).toEqual({
-      failures: 2,
-      success: 2,
+      failures: 1,
+      success: 3,
       total: 4,
       features: {
         1: { success: 2, failures: 0 },
-        2: { success: 0, failures: 2 }
+        2: { success: 1, failures: 1 }
       },
       rules: {
-        CPF: { success: 1, failures: 1 },
+        CPF: { success: 2, failures: 0 },
         NOT_EMPTY: { success: 1, failures: 1 },
       }
     })
@@ -30,6 +30,7 @@ describe('applyValidationRules', () => {
 
   test('operator requires culture type, and engagement_date only if Cx', () => {
     const features = [
+      // NOT_EMPTY not ok CPF ok
       { id: 1, properties: { TYPE: '' }},
       // below is NOT_EMPTY ok but CPF is not
       { id: 2, properties: { TYPE: 'AGR' }},
@@ -44,16 +45,16 @@ describe('applyValidationRules', () => {
     const result = applyValidationRules(AUDITOR_RULES, ...store.collection.features)
 
     expect(result).toEqual({
-      failures: 6,
-      success: 9,
+      failures: 5,
+      success: 10,
       total: 15,
       rules: {
         NOT_EMPTY: { success: 4, failures: 1 },
-        CPF: { success: 3, failures: 2 },
+        CPF: { success: 4, failures: 1 },
         ENGAGEMENT_DATE: { success: 2, failures: 3 }
       },
       features: {
-        1: { success: 0, failures: 3 },
+        1: { success: 1, failures: 2 },
         2: { success: 1, failures: 2 },
         3: { success: 2, failures: 1 },
         4: { success: 3, failures: 0 },


### PR DESCRIPTION
La possibilité d'ajouter des parcelles + la migration CPF fait que le type PAC des parcelles est parfois absent (et c'est normal !)