### PR TITLE
Ajoute un statut intermédiaire de niveau de conversion

### DIFF
--- a/src/components/Certification/EngagementLevelModal.vue
+++ b/src/components/Certification/EngagementLevelModal.vue
@@ -9,16 +9,7 @@
     </div>
 
     <form id="mass-edit-form" @submit.prevent="emit('submit', { ids: selectedIds, patch })">
-      <div class="fr-input-group">
-        <label class="fr-label">Niveau de conversion</label>
-
-        <div class="fr-radio-group fr-my-1w" v-for="niveau in conversionLevels" :key="niveau.value">
-          <input type="radio" :id="'conversion-' + niveau.value" :value="niveau.value" v-model="patch.conversion_niveau" name="conversion_niveau">
-          <label class="fr-label" :for="'conversion-' + niveau.value">
-            {{ niveau.label }}
-          </label>
-        </div>
-      </div>
+      <ConversionLevelSelector v-model="patch.conversion_niveau" />
     </form>
 
     <template #footer>
@@ -36,10 +27,10 @@
 <script setup>
 import { reactive } from 'vue'
 import { storeToRefs } from 'pinia'
-import { userFacingConversionLevels as conversionLevels } from '@/referentiels/ab.js'
 import { useFeaturesStore } from '@/stores/features.js'
 
 import Modal from '@/components/Modal.vue'
+import ConversionLevelSelector from "@/components/Features/ConversionLevelSelector.vue";
 
 defineProps({ })
 const emit = defineEmits(['submit'])

--- a/src/components/Features/ConversionLevel.vue
+++ b/src/components/Features/ConversionLevel.vue
@@ -1,5 +1,5 @@
 <template>
-  <span v-if="!conversionLevel.value" class="fr-badge fr-badge--warning">
+  <span v-if="requiresPrecision" class="fr-badge fr-badge--warning fr-badge--sm">
     {{ conversionLevel.shortLabel }}
   </span>
   <span v-else>
@@ -29,6 +29,7 @@ const props = defineProps({
 const conversionLevel = computed(() => getConversionLevel(props.feature.properties.conversion_niveau))
 const conversionDate = computed(() => props.feature.properties.engagement_date && new Date(props.feature.properties.engagement_date).toISOString())
 const isAB = computed(() => isABLevel(props.feature.properties.conversion_niveau))
+const requiresPrecision = computed(() => !props.feature.properties.conversion_niveau || props.feature.properties.conversion_niveau === 'AB?')
 </script>
 
 <style scoped>

--- a/src/components/Features/ConversionLevelSelector.vue
+++ b/src/components/Features/ConversionLevelSelector.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="fr-input-group">
+    <label class="fr-label">Niveau de conversion</label>
+
+    <div class="fr-radio-group fr-my-1w" v-for="niveau in conversionLevels" :key="niveau.value">
+      <input type="radio" :id="'conversion-' + niveau.value" :value="niveau.value" :checked="niveau.value === modelValue" @change="emit('update:modelValue', niveau.value)" name="conversion_niveau">
+      <label class="fr-label" :for="'conversion-' + niveau.value">
+        {{ niveau.label }}
+      </label>
+    </div>
+
+    <div v-if="modelValue === LEVEL_UNKNOWN" class="fr-hint-text fr-error-text">
+      Le niveau de conversion a besoin d'être indiqué.
+    </div>
+    <div v-if="modelValue === LEVEL_MAYBE_AB" class="fr-hint-text fr-error-text">
+      Le niveau de conversion en agriculture biologique a besoin d'être précisé.
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { LEVEL_UNKNOWN, LEVEL_MAYBE_AB, userFacingConversionLevels as conversionLevels } from '@/referentiels/ab.js';
+
+defineProps({
+  modelValue: {
+    type: String,
+    required: true
+  }
+})
+const emit = defineEmits(['update:modelValue'])
+</script>

--- a/src/components/Features/SingleItemCertificationBodyForm.vue
+++ b/src/components/Features/SingleItemCertificationBodyForm.vue
@@ -18,16 +18,7 @@
       <CultureSelector v-model="patch.CPF" :from-pac="feature.properties.TYPE" />
     </div>
 
-    <div class="fr-input-group">
-      <label class="fr-label">Niveau de conversion</label>
-
-      <div class="fr-radio-group fr-my-1w" v-for="niveau in conversionLevels" :key="niveau.value">
-        <input type="radio" :id="'conversion-' + niveau.value" :value="niveau.value" v-model="patch.conversion_niveau" name="conversion_niveau">
-        <label class="fr-label" :for="'conversion-' + niveau.value">
-          {{ niveau.label }}
-        </label>
-      </div>
-    </div>
+    <ConversionLevelSelector v-model="patch.conversion_niveau" />
 
     <div :class="{'fr-input-group': true, 'fr-input-group--disabled': !isAB}">
       <label class="fr-label">Date d'engagement</label>
@@ -51,8 +42,9 @@
 import { reactive, computed } from 'vue';
 
 import { featureName } from '@/components/Features/index.js'
-import { userFacingConversionLevels as conversionLevels, isABLevel, applyValidationRules, RULE_ENGAGEMENT_DATE } from '@/referentiels/ab.js'
+import { isABLevel, applyValidationRules, RULE_ENGAGEMENT_DATE } from '@/referentiels/ab.js'
 import CultureSelector from "@/components/Features/CultureSelector.vue";
+import ConversionLevelSelector from "@/components/Features/ConversionLevelSelector.vue";
 
 const props = defineProps({
   feature: {

--- a/src/components/Features/ValidationErrors.vue
+++ b/src/components/Features/ValidationErrors.vue
@@ -1,8 +1,9 @@
 <template>
   <p v-for="([ruleId, result]) in validationRulesWithFailures" :key="ruleId">
     {{ ruleId === 'NOT_EMPTY' ? `Il manque un type de culture dans ${result.failures} parcelles.` : '' }}
-    {{ ruleId === 'ENGAGEMENT_DATE' ? `Il manque une date d'engagement et/ou un niveau de conversion dans
-    ${result.failures} parcelles.` : '' }}
+    {{ ruleId === 'ENGAGEMENT_DATE' ? `Il manque une date d'engagement dans ${result.failures} parcelles.` : '' }}
+    {{ ruleId === 'CONVERSION_LEVEL' ? `Il manque un niveau de conversion dans ${result.failures} parcelles.` : '' }}
+    {{ ruleId === 'MAYBE_AB' ? `Le niveau de conversion en agriculture biologique a besoin d'être précisé dans ${result.failures} parcelles.` : '' }}
     {{ ruleId === 'CPF' ? 'Certaines cultures ont besoin d\'être précisées.' : '' }}
   </p>
 </template>

--- a/src/referentiels/ab.js
+++ b/src/referentiels/ab.js
@@ -43,24 +43,30 @@ export const RULE_MAYBE_AB = 'MAYBE_AB'
 export const RULE_CPF = 'CPF'
 
 const VALIDATION_RULES = {
+  // la culture est renseignée
   [RULE_NOT_EMPTY] (feature) {
     return Boolean(feature.properties.CPF)
   },
+  // le code CPF est explicite (il n'y a pas plusieurs choix possibles pour un code)
   [RULE_CPF] (feature) {
     return Boolean(!feature.properties.CPF) || fromCodeCpf(feature.properties.CPF).is_selectable
   },
+  // le niveau de conversion n'est pas renseigné si une culture existe
   [RULE_CONVERSION_LEVEL] (feature) {
     const { conversion_niveau } = feature.properties
     const conversionLevel = getConversionLevel(conversion_niveau)
 
-    return (conversionLevel.value === LEVEL_UNKNOWN) === false
+    return (Boolean(feature.properties.CPF) && conversionLevel.value === LEVEL_UNKNOWN) === false
   },
+  // le produit est "bio", mais on ne sait pas de quel niveau de bio il s'agit
   [RULE_MAYBE_AB] (feature) {
     const { conversion_niveau } = feature.properties
     const conversionLevel = getConversionLevel(conversion_niveau)
 
     return (conversionLevel.value === LEVEL_MAYBE_AB) === false
   },
+  // la date d'engagement est manquante pour des conversions récentes
+  // on dit que c'est OK de ne pas l'avoir en AB, pour accepter des parcellaires certifiés depuis longtemps, avant l'obligation de tracer leur date d'engagement ou de passage en bio
   [RULE_ENGAGEMENT_DATE] (feature) {
     const { conversion_niveau, engagement_date } = feature.properties
     const conversionLevel = getConversionLevel(conversion_niveau)

--- a/src/referentiels/ab.js
+++ b/src/referentiels/ab.js
@@ -36,7 +36,9 @@ export const conversionLevels = [
 export const userFacingConversionLevels = conversionLevels.filter(({ is_selectable }) => is_selectable !== false)
 
 export const RULE_NOT_EMPTY = 'NOT_EMPTY'
+export const RULE_CONVERSION_LEVEL = 'CONVERSION_LEVEL'
 export const RULE_ENGAGEMENT_DATE = 'ENGAGEMENT_DATE'
+export const RULE_MAYBE_AB = 'MAYBE_AB'
 
 export const RULE_CPF = 'CPF'
 
@@ -47,24 +49,32 @@ const VALIDATION_RULES = {
   [RULE_CPF] (feature) {
     return Boolean(!feature.properties.CPF) || fromCodeCpf(feature.properties.CPF).is_selectable
   },
+  [RULE_CONVERSION_LEVEL] (feature) {
+    const { conversion_niveau } = feature.properties
+    const conversionLevel = getConversionLevel(conversion_niveau)
+
+    return (conversionLevel.value === LEVEL_UNKNOWN) === false
+  },
+  [RULE_MAYBE_AB] (feature) {
+    const { conversion_niveau } = feature.properties
+    const conversionLevel = getConversionLevel(conversion_niveau)
+
+    return (conversionLevel.value === LEVEL_MAYBE_AB) === false
+  },
   [RULE_ENGAGEMENT_DATE] (feature) {
     const { conversion_niveau, engagement_date } = feature.properties
     const conversionLevel = getConversionLevel(conversion_niveau)
 
-    if (conversionLevel.value === LEVEL_UNKNOWN) {
+    if ([LEVEL_C1, LEVEL_C2, LEVEL_C3].includes(conversionLevel.value) && !engagement_date) {
       return false
     }
 
-    if ([LEVEL_CONVENTIONAL, LEVEL_AB].includes(conversionLevel.value)) {
-      return true
-    }
-
-    return Boolean(engagement_date)
+    return true
   }
 }
 
 export const OPERATOR_RULES = [RULE_NOT_EMPTY, RULE_CPF]
-export const AUDITOR_RULES = [RULE_NOT_EMPTY, RULE_CPF, RULE_ENGAGEMENT_DATE]
+export const AUDITOR_RULES = [RULE_NOT_EMPTY, RULE_CPF, RULE_CONVERSION_LEVEL, RULE_MAYBE_AB, RULE_ENGAGEMENT_DATE]
 
 export function getConversionLevel (level) {
   return conversionLevels.find(({ value }) => value === level) ?? getConversionLevel(LEVEL_UNKNOWN)

--- a/src/referentiels/ab.js
+++ b/src/referentiels/ab.js
@@ -6,6 +6,7 @@ export const LEVEL_C1 = 'C1'
 export const LEVEL_C2 = 'C2'
 export const LEVEL_C3 = 'C3'
 export const LEVEL_AB = 'AB'
+export const LEVEL_MAYBE_AB = 'AB?'
 
 /** @enum {string} */
 export const CERTIFICATION_STATE = {
@@ -23,15 +24,16 @@ export function isCertificationImmutable (state) {
 }
 
 export const conversionLevels = [
-  { value: LEVEL_UNKNOWN, label: 'Niveau de conversion inconnu', shortLabel: 'Inconnue' },
+  { value: LEVEL_UNKNOWN, label: 'Niveau de conversion inconnu', shortLabel: 'Inconnue', is_selectable: false },
   { value: LEVEL_CONVENTIONAL, label: 'Conventionnel', shortLabel: 'Conventionnel' },
+  { value: LEVEL_MAYBE_AB, label: 'AB — niveau de conversion à préciser', shortLabel: 'à préciser', is_selectable: false },
   { value: LEVEL_C1, label: 'C1 — Première année de conversion', shortLabel: 'C1' },
   { value: LEVEL_C2, label: 'C2 — Deuxième année de conversion', shortLabel: 'C2' },
   { value: LEVEL_C3, label: 'C3 — Troisième année de conversion', shortLabel: 'C3' },
   { value: LEVEL_AB, label: 'AB — Agriculture biologique', shortLabel: 'AB' },
 ]
 
-export const userFacingConversionLevels = conversionLevels.filter(({ value }) => value !== undefined)
+export const userFacingConversionLevels = conversionLevels.filter(({ is_selectable }) => is_selectable !== false)
 
 export const RULE_NOT_EMPTY = 'NOT_EMPTY'
 export const RULE_ENGAGEMENT_DATE = 'ENGAGEMENT_DATE'

--- a/src/referentiels/ab.test.js
+++ b/src/referentiels/ab.test.js
@@ -32,13 +32,15 @@ describe('applyValidationRules', () => {
     const features = [
       // NOT_EMPTY not ok CPF ok
       { id: 1, properties: { TYPE: '' }},
-      // below is NOT_EMPTY ok but CPF is not
+      // below is NOT_EMPTY ok but CPF and CONVERSION_LEVEL are not
       { id: 2, properties: { TYPE: 'AGR' }},
-      // below is NOT_EMPTY and CPF ok
+      // below is NOT_EMPTY and CPF ok, but CONVERSION_LEVEL fails
       { id: 3, properties: { TYPE: 'AIL', conversion_niveau: 'C1' }},
-      // below are okay
-      { id: 4, properties: { TYPE: 'AIL', conversion_niveau: 'AB' }},
-      { id: 5, properties: { TYPE: 'AIL', conversion_niveau: 'C1', engagement_date: '2023-04-23' }},
+      // below is MAYBE_AB
+      { id: 4, properties: { TYPE: 'AIL', conversion_niveau: 'AB?' }},
+      // below are okay (CONVERSION_LEVEL succeeds)
+      { id: 5, properties: { TYPE: 'AIL', conversion_niveau: 'AB' }},
+      { id: 6, properties: { TYPE: 'AIL', conversion_niveau: 'C1', engagement_date: '2023-04-23' }},
     ]
     const store = useFeaturesStore()
     store.setAll(features)
@@ -46,19 +48,22 @@ describe('applyValidationRules', () => {
 
     expect(result).toEqual({
       failures: 5,
-      success: 10,
-      total: 15,
+      success: 25,
+      total: 30,
       rules: {
-        NOT_EMPTY: { success: 4, failures: 1 },
-        CPF: { success: 4, failures: 1 },
-        ENGAGEMENT_DATE: { success: 2, failures: 3 }
+        NOT_EMPTY: { success: 5, failures: 1 },
+        CPF: { success: 5, failures: 1 },
+        MAYBE_AB: { success: 5, failures: 1 },
+        ENGAGEMENT_DATE: { success: 5, failures: 1 },
+        CONVERSION_LEVEL: { success: 5, failures: 1 },
       },
       features: {
-        1: { success: 1, failures: 2 },
-        2: { success: 1, failures: 2 },
-        3: { success: 2, failures: 1 },
-        4: { success: 3, failures: 0 },
-        5: { success: 3, failures: 0 },
+        1: { success: 4, failures: 1 },
+        2: { success: 3, failures: 2 },
+        3: { success: 4, failures: 1 },
+        4: { success: 4, failures: 1 },
+        5: { success: 5, failures: 0 },
+        6: { success: 5, failures: 0 },
       },
     })
   })


### PR DESCRIPTION
On sait qu'une parcelle est "bio" sans savoir quel niveau de conversion ; on demande à préciser.

Avec AgenceBio/cartobio-api#68