### PR TITLE
Utilise les helpers de permission pour déterminer si on cause à un·e OC

### DIFF
--- a/src/components/Features/ConversionLevel.vue
+++ b/src/components/Features/ConversionLevel.vue
@@ -2,11 +2,11 @@
   <span v-if="conversionLevel.value === LEVEL_UNKNOWN" class="fr-badge fr-badge--warning">
     {{ conversionLevel.shortLabel }}
   </span>
-  <span v-else-if="conversionLevel.value === LEVEL_MAYBE_AB" :class="{'fr-badge': isOC, 'fr-badge--warning': isOC, 'fr-badge--no-icon': isOC }">
-    <span v-if="isOC">à préciser</span>
+  <span v-else-if="conversionLevel.value === LEVEL_MAYBE_AB" :class="{'fr-badge': isOc, 'fr-badge--warning': isOc, 'fr-badge--no-icon': isOc }">
+    <span v-if="isOc">à préciser</span>
     <span v-else>{{ conversionLevel.shortLabel }}</span>
 
-    <small v-if="!isOC" class="help">à préciser par l'OC</small>
+    <small v-if="!isOc" class="help">à préciser par l'OC</small>
   </span>
   <span v-else>
     {{ conversionLevel.shortLabel }}
@@ -20,8 +20,9 @@
 import { computed } from 'vue'
 import { LEVEL_MAYBE_AB, LEVEL_UNKNOWN, getConversionLevel, isABLevel } from '@/referentiels/ab.js'
 import { mmyyyy, ddmmmmyyyy } from '@/components/dates.js';
-import { useUserStore } from "@/stores/index.js"
-import { ROLES } from "@/stores/user.js"
+import { storeToRefs } from 'pinia'
+import { usePermissions } from "@/stores/index.js"
+
 
 const props = defineProps({
   feature: {
@@ -33,12 +34,11 @@ const props = defineProps({
     default: false
   }
 })
-const user = useUserStore()
+const { isOc } = storeToRefs(usePermissions())
 
 const conversionLevel = computed(() => getConversionLevel(props.feature.properties.conversion_niveau))
 const conversionDate = computed(() => props.feature.properties.engagement_date && new Date(props.feature.properties.engagement_date).toISOString())
 const isAB = computed(() => isABLevel(props.feature.properties.conversion_niveau))
-const isOC = computed(() => user.isRole(ROLES.OC))
 </script>
 
 <style scoped>

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,3 +1,4 @@
 export { useFeaturesStore } from './features.js'
+export { usePermissions } from './permissions.js'
 export { useRecordStore } from './record.js'
 export { useUserStore } from './user.js'


### PR DESCRIPTION
Au niveau de l'étiquette du niveau de conversion.

Ça résoud un bug où le rôle ne correspondait plus à un identifiant connu (`OC`).