### PR TITLE
Désactive l'autoResize de la Map en Preview

### DIFF
--- a/src/components/Map/Preview.vue
+++ b/src/components/Map/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <MapContainer :controls="controls" class="map map--preview" :options="{ interactive: false, hash: false }" :bounds="mapBounds">
+  <MapContainer :controls="controls" class="map map--preview" :options="{ interactive: false, hash: false, trackResize: false }" :bounds="mapBounds">
     <GeojsonLayer :style="baseStyle" name="base" />
     <GeojsonLayer :data="collection" name="parcellaire-operateur" />
   </MapContainer>


### PR DESCRIPTION
Dans le Webcomponent, ça mettait le bazar en créant un scroll infini