### PR TITLE
Explicite l'utilisation de eslint-plugin-vue

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,4 +1,6 @@
 {
+  "module": "ES2020",
+  "include": ["src/**/*.js", "src/**/*.vue"],
   "compilerOptions": {
     "baseUrl": ".",
     "target": "es6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@vue/test-utils": "^2.3.2",
         "autoprefixer": "^10.4.2",
         "eslint": "^8.6.0",
+        "eslint-plugin-vue": "^9.15.1",
         "jsdom": "^22.0.0",
         "postcss-preset-env": "^8.3.2",
         "typescript": "^5.0.4",
@@ -2265,8 +2266,7 @@
     "node_modules/boolbase": {
       "version": "1.0.0",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3020,10 +3020,10 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.14.0",
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.15.1.tgz",
+      "integrity": "sha512-CJE/oZOslvmAR9hf8SClTdQ9JLweghT6JCBQNrT2Iel1uVw0W0OLJxzvPd6CxmABKCvLrtyDnqGV37O7KQv6+A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.3.0",
         "natural-compare": "^1.4.0",
@@ -4491,7 +4491,6 @@
       "version": "2.1.1",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "preview": "vite preview",
     "start": "vite",
     "test": "vitest",
-    "posttest": "eslint ./src"
+    "posttest": "eslint --ext .js,.vue  ./src"
   },
   "engines": {
     "node": "^18.0.0"
@@ -48,6 +48,7 @@
     "@vue/test-utils": "^2.3.2",
     "autoprefixer": "^10.4.2",
     "eslint": "^8.6.0",
+    "eslint-plugin-vue": "^9.15.1",
     "jsdom": "^22.0.0",
     "postcss-preset-env": "^8.3.2",
     "typescript": "^5.0.4",
@@ -57,12 +58,9 @@
   },
   "eslintConfig": {
     "root": true,
-    "env": {
-      "node": true
-    },
     "extends": [
-      "plugin:vue/vue3-essential",
       "eslint:recommended",
+      "plugin:vue/vue3-essential",
       "@vue/eslint-config-typescript/recommended"
     ],
     "rules": {
@@ -72,6 +70,15 @@
       "vue/no-multiple-template-root": "off",
       "vue/script-setup-uses-vars": "error"
     },
+    "overrides": [
+      {
+        "files": ["vite*.config.js"],
+        "env": {
+          "node": true
+        }
+      }
+    ],
+    "parser": "vue-eslint-parser",
     "parserOptions": {
       "ecmaVersion": "latest",
       "sourceType": "module"


### PR DESCRIPTION
Le commit 36ddc03db46540cbdb1ce0e8d6c5eb3657305a2b règle un problème de variable non-déclaré dans un `<script setup>`. Eslint aurait dû capter cette erreur.

Et pour l'instant, cette PR ne résoud pas le problème :-(