### PR TITLE
Feedback d'erreur minimal pour l'utilisateur

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "vue": "^3.2.25",
         "vue-matomo": "^4.1.0",
         "vue-router": "^4.0.12",
+        "vue3-toastify": "^0.1.11",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -1044,10 +1045,11 @@
       }
     },
     "node_modules/@gouvfr/dsfr": {
-      "version": "1.9.3",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.10.0.tgz",
+      "integrity": "sha512-fHqGCvc8jGtkX2AKRCWi9o3jf/kirP/BeeZ2FBVGwS9Oxd8KsG22xk/6Tls8nA+qPaI+2ZkZQxATBV8KlhwNhQ==",
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18.16.1"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -6441,6 +6443,23 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue3-toastify": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/vue3-toastify/-/vue3-toastify-0.1.11.tgz",
+      "integrity": "sha512-xOghHidGEuzLaDp9yiCdEt53c02x16m3ai/G3vq9d7XST77YAaPk1p1D0DiTbbpYUvGQGC1SYA7e3Z9+IP3r6w==",
+      "engines": {
+        "node": ">=16",
+        "npm": ">=7"
+      },
+      "peerDependencies": {
+        "vue": ">=3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "vue": "^3.2.25",
     "vue-matomo": "^4.1.0",
     "vue-router": "^4.0.12",
+    "vue3-toastify": "^0.1.11",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/src/components/Features/Table.vue
+++ b/src/components/Features/Table.vue
@@ -85,6 +85,7 @@ import Modal from '@/components/Modal.vue'
 import { surface, inHa, getFeatureGroups, groupingChoices, getFeatureById } from './index.js'
 import { submitParcellesChanges } from '@/cartobio-api.js'
 import { usePermissions } from "@/stores/permissions.js"
+import { toast } from "vue3-toastify"
 
 const props = defineProps({
   operator: {
@@ -101,7 +102,6 @@ const props = defineProps({
 })
 
 const isSaving = ref(false)
-const savingResult = ref(null)
 const showModal = computed(() => Boolean(editedFeatureId.value))
 const store = useFeaturesStore()
 
@@ -142,17 +142,15 @@ function doSave (geojson) {
   setTimeout(async () => {
     try {
       await submitParcellesChanges ({ geojson, operatorId, ocId, ocLabel, numeroBio })
-      savingResult.value = {
-        type: 'success',
-        message: "Parcellaire correctement sauvegardé sur les serveurs CartoBio."
-      }
+      toast.success(
+        "Modification enregistrée."
+      )
     }
     catch (error) {
       console.error(error)
-      savingResult.value = {
-        type: 'error',
-        message: "Une erreur d'enregistrement s'est produite. Les données n'ont pas été sauvegardées sur les serveurs CartoBio."
-      }
+      toast.error(
+        "Une erreur d'enregistrement s'est produite. Les données n'ont pas été sauvegardées sur les serveurs CartoBio."
+      )
     }
 
     isSaving.value = false

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ import { createHead } from '@unhead/vue'
 import * as Sentry from '@sentry/vue'
 import routes from '~pages'
 import Matomo from 'vue-matomo'
+import Vue3Toastify, { toast } from 'vue3-toastify'
+import 'vue3-toastify/dist/index.css';
 
 import { useFeaturesStore, useRecordStore, useUserStore } from '@/stores/index.js'
 import App from './App.vue'
@@ -39,6 +41,13 @@ const app = createApp(App)
   .use(router)
   .use(head)
   .use(pinia)
+  .use(
+    Vue3Toastify,
+    {
+      autoClose: 5000,
+      position: toast.POSITION.BOTTOM_RIGHT,
+    }
+  )
   .use(Matomo, {
     router,
     siteId,
@@ -49,6 +58,16 @@ const app = createApp(App)
     trackerUrl: 'https://cartobio.agencebio.org/s/',
     trackerScriptUrl: 'https://cartobio.agencebio.org/s/index.js',
   })
+
+app.config.errorHandler = (err) => {
+  if (err.code === "ERR_NETWORK") {
+    toast.error('Une erreur de réseau est survenue. Vérifiez votre connexion internet.')
+  }
+
+  toast.error('Une erreur est survenue. Nous avons été informés et résoudrons ceci au plus vite.')
+
+  throw err;
+}
 
 // this is sync because we need to know the user role before rendering the app
 const userStore = useUserStore()
@@ -131,3 +150,13 @@ router.beforeEach(async (to, from) => {
   }
 })
 
+router.onError((error) => {
+  console.error(error)
+
+  if (error.name === "TypeError" || error.code === "ERR_NETWORK") {
+    toast.error('La page n\'a pas pu être chargée. Vérifiez votre connexion internet.')
+    return
+  }
+
+  toast.error('Une erreur est survenue. La page n\'a pas pu être chargée.')
+})

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -806,3 +806,39 @@
   --map-legend-conventionnelle: #ffd6a4;
   --map-legend-conventionnelle-border: #ffc177;
 }
+
+:root {
+  --toastify-color-light: #fff;
+  --toastify-color-dark: #121212;
+  --toastify-color-info: var(--info-425-625);
+  --toastify-color-success: var(--success-425-625);
+  --toastify-color-warning: var(--warning-425-625);
+  --toastify-color-error: var(--error-425-625);
+  --toastify-color-transparent: rgba(255, 255, 255, 0.7);
+
+  --toastify-icon-color-info: var(--info-425-625);
+  --toastify-icon-color-success: var(--success-425-625);
+  --toastify-icon-color-warning: var(--warning-425-625);
+  --toastify-icon-color-error: var(--error-425-625);
+
+  --toastify-toast-width: 320px;
+  --toastify-toast-background: #fff;
+  --toastify-toast-min-height: 64px;
+  --toastify-toast-max-height: 800px;
+  --toastify-font-family: "Marianne", arial, sans-serif;
+  --toastify-z-index: 9999;
+
+  --toastify-text-color-light: var(--text-default-grey);
+  --toastify-text-color-dark: #cecece;
+
+  --toastify-text-color-info: var(--text-default-info);
+  --toastify-text-color-success: var(--text-default-success);
+  --toastify-text-color-warning: var(--text-default-warning);
+  --toastify-text-color-error: var(--text-default-error);
+
+  --toastify-spinner-color: var(--text-default-grey);
+  --toastify-spinner-color-empty-area: #e0e0e0;
+
+  /* For messages with no level */
+  --toastify-color-progress-light: var(--border-active-blue-france);
+}


### PR DESCRIPTION
Voir https://trello.com/c/4Frh22k1/1488-feedback-g%C3%A9n%C3%A9rique-minimal-toast-ou-alert

Par défaut :
* affiche un feedback pour les erreurs de navigation due à un réseau coupé 
* affiche un feedback utilisateur pour les erreurs front non gérées
* transmets toujours les erreurs à Sentry et à la console exactement comme avant