### PR TITLE
Ajoute la règle vue/no-undef-properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
       "node": true
     },
     "extends": [
-      "plugin:vue/vue3-essential",
       "eslint:recommended",
+      "plugin:vue/vue3-essential",
       "@vue/eslint-config-typescript/recommended"
     ],
     "rules": {
@@ -71,6 +71,7 @@
       "vue/multi-word-component-names": "off",
       "vue/no-mutating-props": "warn",
       "vue/no-multiple-template-root": "off",
+      "vue/no-undef-properties": "warn",
       "vue/script-setup-uses-vars": "error"
     },
     "parserOptions": {

--- a/src/components/Certification/SendOffModal.vue
+++ b/src/components/Certification/SendOffModal.vue
@@ -23,7 +23,7 @@
     <template #footer>
       <ul class="fr-btns-group fr-btns-group--inline-lg">
         <li>
-          <button class="fr-btn" @click="excelExport" form="sendoff-form">
+          <button class="fr-btn" form="sendoff-form">
             Enregistrer
           </button>
         </li>

--- a/src/components/Features/Table.vue
+++ b/src/components/Features/Table.vue
@@ -102,8 +102,8 @@ const props = defineProps({
     type: Object,
     required: true
   },
-  'edit-form': Object,
-  'validation-rules': Object,
+  editForm: Object,
+  validationRules: Object,
   massActions: Array,
 })
 

--- a/src/components/OperatorSetup/ImportPre.vue
+++ b/src/components/OperatorSetup/ImportPre.vue
@@ -37,5 +37,4 @@ const warnings = inject('importWarnings')
 const emit = defineEmits(['submit', 'cancel'])
 
 const surfaceTotale = computed(() => inHa(surface(featureCollection.value)))
-const hasErrors = computed(() => warnings.value.length > 0)
 </script>

--- a/src/components/OperatorSetup/MesParcelles.vue
+++ b/src/components/OperatorSetup/MesParcelles.vue
@@ -94,6 +94,7 @@ async function handleLoginImport ({ email, millesime, password, server }) {
 
   try {
     const { data: geojson } = await axios.post(`${VUE_APP_API_ENDPOINT}/v2/import/mesparcelles/login`, { email, millesime, password, server })
+    emit('upload:complete', { geojson, source, warnings: [] })
   } catch (error) {
     if (error.response.status === 401) {
       return errors.value = ['Identifiants incorrects.']
@@ -104,7 +105,6 @@ async function handleLoginImport ({ email, millesime, password, server }) {
     }
   }
 
-  emit('upload:complete', { geojson, source, warnings: [] })
 }
 
 </script>

--- a/src/components/OperatorSetup/Telepac.vue
+++ b/src/components/OperatorSetup/Telepac.vue
@@ -34,7 +34,7 @@ const erreur = ref('')
 async function handleFileUpload () {
   const warnings = []
   const [archive] = fileInput.value.files
-  const { campagne, pacage } = deriveFromFilename(archive?.name)
+  const { campagne } = deriveFromFilename(archive?.name)
 
   emit('upload:start')
 

--- a/src/components/Partners/section.vue
+++ b/src/components/Partners/section.vue
@@ -57,9 +57,9 @@
 
 <script setup>
 defineProps({
-  'section-administrations': Boolean,
-  'section-oc': Boolean,
-  'section-business': Boolean
+  sectionAdministrations: Boolean,
+  sectionOc: Boolean,
+  sectionBusiness: Boolean
 })
 </script>
 

--- a/src/stores/features.js
+++ b/src/stores/features.js
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { computed, reactive, ref, watch } from 'vue'
-import { fromCodeCpf, fromCodePacStrict } from "@agencebio/rosetta-cultures"
 
 export function collectIds (features) {
   return features.map(({ id }) => id).sort()

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ const cwd = process.cwd()
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  loadEnv(mode, process.cwd(), '')
 
   return {
     envPrefix: 'VUE_APP_',

--- a/widget/Notification.ce.vue
+++ b/widget/Notification.ce.vue
@@ -25,7 +25,7 @@ import { useUserStore } from '@/stores/user.js'
 import { exchangeNotificationToken } from '@/cartobio-api.js'
 import { sources } from '@/referentiels/imports.js'
 
-const props = defineProps({ 'auth-token': String })
+const props = defineProps({ authToken: String })
 const emit = defineEmits(['error', 'import:ready', 'import:started', 'import:complete', 'import:errored'])
 
 const uploadState = ref(null)


### PR DESCRIPTION
Ajoute la règle [vue/no-undef-properties](https://eslint.vuejs.org/rules/no-undef-properties.html) à la config Eslint.

Pour que cela fonctionne et qu'il n'y ait pas de faux positif, `defineProps` doit utiliser du camelCase.