### PR TITLE
Transforme la page "exploitations/setup" en composant

### DIFF
--- a/src/components/Certification/OperatorSetup/index.vue
+++ b/src/components/Certification/OperatorSetup/index.vue
@@ -114,11 +114,10 @@ import telepacModal from '@/components/Certification/OperatorSetup/TelepacModal.
 import RPGModal from '@/components/Certification/OperatorSetup/RPGModal.vue'
 
 import { useTélépac } from '@/referentiels/pac.js'
-import { useFeaturesStore, useRecordStore } from '@/stores/index.js'
+import { useRecordStore } from '@/stores/index.js'
 import { submitParcellesChanges } from '@/cartobio-api.js'
 import { now } from '@/components/dates.js'
 
-const featureStore = useFeaturesStore()
 const recordStore = useRecordStore()
 const télépac = useTélépac()
 
@@ -149,7 +148,6 @@ async function handleUpload ({ geojson, source }) {
   })
 
   recordStore.update(record)
-  featureStore.setAll(record.parcelles.features)
 
   setupFromTelepacModal.value = false
   setupFromRPGModal.value = false

--- a/src/components/Features/ExportStrategies/CertisExporter.js
+++ b/src/components/Features/ExportStrategies/CertisExporter.js
@@ -1,6 +1,6 @@
 import { utils, write } from 'xlsx'
 import { fromCodeCpf } from '@agencebio/rosetta-cultures'
-import { GROUPE_NIVEAU_CONVERSION, featureName, getFeatureGroups, surface } from '@/components/Features/index.js'
+import { GROUPE_NIVEAU_CONVERSION, getFeatureGroups, surface } from '@/components/Features/index.js'
 
 import BaseExporter, { generateAutresInfos } from "@/components/Features/ExportStrategies/BaseExporter.js";
 
@@ -75,7 +75,7 @@ const getSheet = ({ featureCollection, operator, record }) => {
     { wch: 40 },
   ]
 
-  sheet_add_aoa(sheet, featureCollection.features.map(({ id, geometry, properties }) => {
+  sheet_add_aoa(sheet, featureCollection.features.map(({ geometry, properties }) => {
     const surfaceHa = surface(geometry) / 10_000
     const culture = fromCodeCpf(properties.cultures.at(0)?.CPF)
 

--- a/src/components/Features/ExportStrategies/DefaultExporter.js
+++ b/src/components/Features/ExportStrategies/DefaultExporter.js
@@ -1,6 +1,6 @@
 import { utils, write } from 'xlsx'
 import { fromCodeCpf } from '@agencebio/rosetta-cultures'
-import { cultureLabels, surface } from '@/components/Features/index.js'
+import { surface } from '@/components/Features/index.js'
 import BaseExporter, { generateAutresInfos } from "@/components/Features/ExportStrategies/BaseExporter.js";
 
 const { book_new, aoa_to_sheet, sheet_add_aoa, book_append_sheet } = utils

--- a/src/components/Operator/DeleteParcelaireModal.vue
+++ b/src/components/Operator/DeleteParcelaireModal.vue
@@ -30,10 +30,7 @@
 <script setup>
 import Modal from "@/components/Modal.vue"
 import { deleteRecord } from "@/cartobio-api.js"
-import { useRecordStore, useUserStore } from "@/stores/index.js"
-import { useFeaturesStore } from "@/stores/features.js"
-import { ROLES } from "@/stores/user.js"
-import { useRouter } from "vue-router"
+import { useRecordStore } from "@/stores/index.js"
 import { ref } from "vue"
 
 const props = defineProps({
@@ -45,20 +42,12 @@ const props = defineProps({
 
 const modal = ref(null)
 const recordStore = useRecordStore()
-const featuresStore = useFeaturesStore()
-const userStore = useUserStore()
-const router = useRouter()
 
 async function handleDelete() {
   const record = await deleteRecord(props.operator.id)
 
-  if (userStore.roles.includes(ROLES.OPERATEUR)) {
-    return router.push('/exploitation/setup')
-  }
-
   // we reset the current state of operator and features
   recordStore.reset()
-  featuresStore.setAll([])
   // ... then restore the operator data (otherwise we loose the initial context)
   recordStore.update(record)
   modal.value?.$emit('update:modelValue', false)

--- a/src/components/Operator/Setup.vue
+++ b/src/components/Operator/Setup.vue
@@ -1,11 +1,3 @@
-<route lang="yaml">
-classNames: fr-container fr-my-5w
-meta:
-  requiresAuth: true
-  seo:
-    title: Importer mon parcellaire existant
-</route>
-
 <template>
   <div class="fr-container fr-my-5w">
     <div class="fr-stepper">
@@ -50,9 +42,9 @@ meta:
         Votre organisme de certification y aura accès pour votre audit.
       </p>
 
-      <router-link to="/exploitation/parcellaire" class="fr-btn">
+      <button type="button" @click="emit('submit', record)" class="fr-btn">
         Accéder à mon parcellaire
-      </router-link>
+      </button>
     </section>
   </div>
 </template>
@@ -62,6 +54,9 @@ import { computed, readonly, ref } from 'vue'
 import { statsPush } from '@/stats.js'
 
 import OperatorSetup from '@/components/OperatorSetup/index.vue'
+
+const emit = defineEmits(['submit'])
+const record = ref(null)
 
 const importTool = ref('')
 
@@ -90,9 +85,12 @@ function onUploadPreview () {
   currentStepIndex.value += 1
 }
 
-function onSuccess () {
+function onSuccess ({ record: newRecord }) {
   statsPush(['trackEvent', 'setup', `import:${importTool.value}`, 'ok'])
   currentStepIndex.value += 1
+
+  // we store the record to delay the propagation of the record
+  record.value = newRecord
 }
 
 function onError () {
@@ -107,20 +105,5 @@ function onError () {
 
 .fr-text--lg {
   max-width: 40rem;
-}
-
-.sources {
-  display: flex;
-  gap: 1rem;
-  list-style: none;
-  padding: 0;
-}
-
-article .screenshot {
-  max-width: min(500px, 50vw);
-}
-
-details.help summary {
-  display: block;
 }
 </style>

--- a/src/components/OperatorSetup/index.vue
+++ b/src/components/OperatorSetup/index.vue
@@ -71,15 +71,20 @@ function handleCancel () {
 }
 
 async function handleUpload () {
+  const { id: operatorId, numeroBio, organismeCertificateur } = user.value
+  const { id: ocId, nom: ocLabel } = organismeCertificateur
+
   const geojson = toRaw(featureCollection.value)
   const source = toRaw(featureSource.value)
 
   try {
-    await submitParcellesChanges({
+    const record = await submitParcellesChanges({
       geojson,
+      ocId,
+      ocLabel,
       // @todo ensure this comes from an operator store, and not a user store (userId != operatorId)
-      operatorId: user.value.id,
-      numeroBio: user.value.numeroBio,
+      operatorId,
+      numeroBio,
       metadata: {
         source,
         sourceLastUpdate: now(),
@@ -87,7 +92,7 @@ async function handleUpload () {
       }
     })
 
-    emit('import:complete', { geojson, source })
+    emit('import:complete', { geojson, source, record })
   }
   catch (error) {
     emit('import:error', error)

--- a/src/main.js
+++ b/src/main.js
@@ -119,12 +119,8 @@ router.beforeEach(async (to, from) => {
   // Preload store for checking permissions
   if (to.params.id || userStore.roles.includes(ROLES.OPERATEUR)) {
     const recordStore = useRecordStore()
-    const featuresStore = useFeaturesStore()
     const record = await getOperatorParcelles(to.params.id || userStore.user.id)
     recordStore.update(record)
-    if (record.parcelles) {
-      featuresStore.setAll(record.parcelles.features)
-    }
   }
 
   if (to.path === '/login/agencebio') {

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import Matomo from 'vue-matomo'
 import Vue3Toastify, { toast } from 'vue3-toastify'
 import 'vue3-toastify/dist/index.css';
 
-import { useFeaturesStore, useRecordStore, useUserStore } from '@/stores/index.js'
+import { useRecordStore, useUserStore } from '@/stores/index.js'
 import App from './App.vue'
 import { version } from "../package.json"
 import { usePermissions } from "@/stores/permissions.js"

--- a/src/pages/certification/exploitations/[id]/index.vue
+++ b/src/pages/certification/exploitations/[id]/index.vue
@@ -16,12 +16,12 @@ meta:
         </p>
 
         <OperatorSummary :operator="record.operator" :record="recordStore.record" />
-        <CertificationSummary v-if="!needsSetup" :operator="record.operator" :record="recordStore.record" :features="featureStore.collection" :validation-rules="validationRules" />
-        <FeaturesTable v-if="!needsSetup" :operator="record.operator" :features="featureStore.collection" :edit-form="EditForm" :validation-rules="validationRules" :mass-actions="massActions" />
-        <OperatorSetup v-if="needsSetup" :operator="record.operator" />
+        <CertificationSummary v-if="recordStore.isSetup" :operator="record.operator" :record="recordStore.record" :features="featureStore.collection" :validation-rules="validationRules" />
+        <FeaturesTable v-if="recordStore.isSetup" :operator="record.operator" :features="featureStore.collection" :edit-form="EditForm" :validation-rules="validationRules" :mass-actions="massActions" />
+        <OperatorSetup v-if="!recordStore.isSetup" />
       </div>
 
-      <div class="fr-col-6 fr-col--map" v-if="!needsSetup">
+      <div class="fr-col-6 fr-col--map" v-if="recordStore.isSetup">
         <div class="sticky-top" :class="{ 'sticky-top--force-height': isMapFullSize }">
           <div :class="{ 'full-size-map fr-card fr-card--shadow fr-p-2w': isMapFullSize }">
             <MapContainer class="map" :class="{ 'map--full-size': isMapFullSize }" :mode="isMapFullSize ? 'fullsize' : 'compact'" :bounds="mapBounds" @load="setupWatchers">
@@ -59,6 +59,7 @@ meta:
 
 <script setup>
 import { computed, markRaw, readonly, ref, shallowRef } from 'vue'
+import { storeToRefs } from 'pinia'
 import bbox from '@turf/bbox'
 
 import MapContainer from '@/components/Map/MapContainer.vue'
@@ -89,7 +90,7 @@ defineProps({
 
 const featureStore = useFeaturesStore()
 const recordStore = useRecordStore()
-const record = recordStore.record
+const { record } = storeToRefs(recordStore)
 const mapRef = shallowRef(null);
 const showSurroundings = ref(false);
 const isMapFullSize = ref(false)
@@ -104,8 +105,7 @@ const massActions = [
   { label: 'Modifier le niveau de conversion', component: markRaw(EngagementLevelModal) },
 ]
 
-const needsSetup = computed(() => featureStore.collection.features.length === 0 && !recordStore.record.metadata.source)
-const mapBounds = computed(() => needsSetup.value ? [] : bbox(featureStore.collection))
+const mapBounds = computed(() => recordStore.isSetup ? bbox(featureStore.collection) : [])
 
 function focusOnOriginalBbox () {
   zoomInto(featureStore.collection, { maxZoom: 12 })

--- a/src/pages/exploitation/parcellaire.vue
+++ b/src/pages/exploitation/parcellaire.vue
@@ -6,7 +6,8 @@ meta:
 </route>
 
 <template>
-  <section class="fr-container fr-py-2w">
+  <OperatorSetup v-if="!recordStore.isSetup" @submit="handleSetup" />
+  <section class="fr-container fr-py-2w" v-else>
     <div class="fr-grid-row fr-grid-row--gutters">
       <div class="fr-col-6">
         <OperatorSummary :operator="record.operator" :record="record" />
@@ -37,8 +38,8 @@ meta:
               </template>
             </MapContainer>
             <div class="fr-toggle">
-                <input type="checkbox" v-model="showSurroundings" class="fr-toggle__input" id="toggle-surroundings">
-                <label class="fr-toggle__label" for="toggle-surroundings">Parcelles environnantes</label>
+              <input type="checkbox" v-model="showSurroundings" class="fr-toggle__input" id="toggle-surroundings">
+              <label class="fr-toggle__label" for="toggle-surroundings">Parcelles environnantes</label>
             </div>
           </div>
         </div>
@@ -49,6 +50,7 @@ meta:
 
 <script setup>
 import { computed, markRaw, readonly, ref, shallowRef } from 'vue'
+import { storeToRefs } from 'pinia'
 import bbox from '@turf/bbox'
 
 import FeaturesTable from '@/components/Features/Table.vue'
@@ -57,17 +59,15 @@ import GeojsonLayer from '@/components/Map/GeojsonLayer.vue'
 import baseStyle from '@/map-styles/base.json'
 import EditForm from '@/components/Features/SingleItemOperatorForm.vue'
 import OperatorSummary from '@/components/Operator/Summary.vue'
+import OperatorSetup from '@/components/Operator/Setup.vue'
 import CultureTypeModal from '@/components/Operator/CultureTypeModal.vue'
 
-import { useFeaturesStore } from '@/stores/features.js'
+import { useFeaturesStore, usePermissions, useRecordStore } from "@/stores/index.js"
 import { applyValidationRules, OPERATOR_RULES } from '@/referentiels/ab.js'
 import surroundingsStyle from "@/map-styles/surroundings.json";
 import cadastreStyle from "@/map-styles/cadastre.json";
 import SurroundingsLegend from "@/components/Map/SurroundingsLegend.vue";
 import ValidationErrors from "@/components/Features/ValidationErrors.vue"
-import { useRecordStore, useUserStore } from "@/stores/index.js"
-import { useRouter } from "vue-router"
-import { usePermissions } from "@/stores/permissions.js"
 
 const validationRules = readonly({
   rules: OPERATOR_RULES,
@@ -81,25 +81,9 @@ const massActions = permissions.canChangeCulture ? [
   { label: 'Modifier les cultures', component: markRaw(CultureTypeModal) },
 ] : []
 
-const router = useRouter()
-const userStore = useUserStore()
 const recordStore = useRecordStore()
 const featureStore = useFeaturesStore()
-const record = recordStore.record
-
-try {
-  if (!record || !record.record_id) {
-    router.push('/exploitation/setup')
-  }
-} catch (error) {
-  // token has expired
-  if (error.response.status === 401) {
-    userStore.logout()
-    router.push('/login')
-  }
-}
-
-
+const { record } = storeToRefs(recordStore)
 
 const showSurroundings = ref(false)
 
@@ -107,7 +91,7 @@ const isMapFullSize = ref(false)
 
 const mapRef = shallowRef(null)
 
-const mapBounds = computed(() => bbox(featureStore.collection))
+const mapBounds = computed(() => recordStore.isSetup ? bbox(featureStore.collection) : [])
 
 function setupWatchers (map) {
   mapRef.value = map
@@ -125,6 +109,10 @@ function zoomInto (featureOrFeatureCollection, { maxZoom }) {
   if (center && zoom) {
     mapRef.value.flyTo({ center, zoom, bearing })
   }
+}
+
+function handleSetup (record) {
+  recordStore.update(record)
 }
 </script>
 

--- a/src/pages/exploitations/[id]/ajout-parcelle.vue
+++ b/src/pages/exploitations/[id]/ajout-parcelle.vue
@@ -20,7 +20,7 @@
       </div>
 
       <div class="fr-col-6">
-        <MapContainer v-if="!needsSetup" :options="{ interactive: true }" class="map" :bounds="mapBounds" @load="setupWatchers">
+        <MapContainer v-if="recordStore.isSetup" :options="{ interactive: true }" class="map" :bounds="mapBounds" @load="setupWatchers">
           <GeojsonLayer :style="baseStyle" name="base" />
           <GeojsonLayer :style="cadastreStyle" name="cadastre" />
           <GeojsonLayer :data="featureStore.collection" name="parcellaire-operateur" />
@@ -64,8 +64,7 @@ const permissions = usePermissions()
 const record = recordStore.record
 
 const pendingChangesCollection = shallowRef()
-const needsSetup = computed(() => featureStore.collection.features.length === 0 && !record.metadata.source)
-const mapBounds = computed(() => needsSetup.value ? [] : bbox(featureStore.collection))
+const mapBounds = computed(() => recordStore.isSetup ? bbox(featureStore.collection) : [])
 
 const EditForm = computed(() => markRaw(permissions.isOc ? CertificationBodyEditForm : OperatorEditForm))
 const backLink = computed(() => permissions.isOc ?

--- a/src/stores/features.js
+++ b/src/stores/features.js
@@ -25,6 +25,8 @@ export const useFeaturesStore = defineStore('features', () => {
     return activeId.value ? getFeatureById(activeId.value) : null
   })
 
+  const hasFeatures = computed(() => all.value.length > 0)
+
   const hoveredFeature = computed(() => {
     return hoveredId.value ? getFeatureById(hoveredId.value) : null
   })
@@ -136,6 +138,7 @@ export const useFeaturesStore = defineStore('features', () => {
     selectedIds,
     // computed
     activeFeature,
+    hasFeatures,
     hoveredFeature,
     selectedFeatures,
     allSelected,

--- a/src/stores/record.js
+++ b/src/stores/record.js
@@ -1,9 +1,12 @@
 import { defineStore } from 'pinia'
-import { reactive } from 'vue'
+import { computed, reactive } from 'vue'
+import { useFeaturesStore } from "@/stores/index.js"
 
 /** @typedef {import('@/cartobio-api.js').StrictRecord} StrictRecord */
 
 export const useRecordStore = defineStore('record', () => {
+  const featuresStore = useFeaturesStore()
+
   const initialState = {
     record_id: null,
     certification_state: null,
@@ -32,14 +35,25 @@ export const useRecordStore = defineStore('record', () => {
         record[key] = updatedRecord[key]
       }
     })
+
+    if (updatedRecord.parcelles) {
+      featuresStore.setAll(updatedRecord.parcelles.features)
+    }
   }
 
   function reset() {
     update({ ...initialState, metadata: { ...initialState.metadata } })
+    featuresStore.setAll([])
   }
+
+  const exists = computed(() => record.record_id)
+  const isSetup = computed(() => record.record_id && record.metadata.source)
 
   return {
     record,
+    // computed
+    exists,
+    isSetup,
     // methods
     update,
     reset


### PR DESCRIPTION
Quelques détails : 

- factorisation du computed `needsSetup` en un getter de store `isSetup`
- on n'a plus à rediriger vers une autre page (l'état du `RecordStore`/`FeaturesStore` fait l'affaire)
- ça corrige un bug où on n'était plus en mesure de créer de parcellaire 🙃 (à cause des contraintes de schéma d'API qui n'étaient pas respectées)
- ça corrige le bug Sentry `CARTOBIO-FRONT-1Z` (`Invalid LngLat latitude value: must be between -90 and 90`) — qui se produisait en tentant d'afficher la carte sans featureCollection/avec une bbox foireuse (problème résolu sur les autres composants sauf la page `exploitation/parcellaire.vue`)