### PR TITLE
Ajoute useContentTracking pour gérer le content tracking Matomo

### DIFF
--- a/src/components/Map/SurroundingsLegend.vue
+++ b/src/components/Map/SurroundingsLegend.vue
@@ -19,6 +19,9 @@
 
 <script setup>
 import Legend from "@/components/Map/Legend.vue";
+import { useContentTracking } from "@/stats.js"
+
+useContentTracking()
 
 defineProps({
   operateur: {

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -30,6 +30,9 @@
 import { onBeforeUnmount, ref, watchEffect } from 'vue'
 import { useHead } from '@unhead/vue'
 import { onKeyStroke } from '@vueuse/core'
+import { useContentTracking } from "@/stats.js"
+
+useContentTracking()
 
 const emit = defineEmits(['update:modelValue'])
 const props = defineProps({

--- a/src/main.js
+++ b/src/main.js
@@ -59,10 +59,6 @@ const app = createApp(App)
     trackerScriptUrl: 'https://cartobio.agencebio.org/s/index.js',
     trackSiteSearch: (to) => to.path === '/certification/exploitations' && to.query.search || null,
   })
-  .use(() => {
-    window._paq = window._paq || [];
-    window._paq.push(['trackContentImpressionsWithinNode', document.getElementById('app')]);
-  })
 
 // this is sync because we need to know the user role before rendering the app
 const userStore = useUserStore()

--- a/src/stats.js
+++ b/src/stats.js
@@ -7,3 +7,7 @@ export function statsPush (args) {
     window._paq.push(args)
   }
 }
+
+export function useContentTracking () {
+  statsPush(['trackContentImpressionsWithinNode', document.getElementById('app')]);
+}


### PR DESCRIPTION
En fait `trackContentImpressionsWithinNode` doit être appelé à chaque mise à jour du dit content.

https://developer.matomo.org/guides/spa-tracking