### PR TITLE
Ajoute des tests de permissions, de dates et de niveaux de conversion

### DIFF
--- a/src/components/Features/index.js
+++ b/src/components/Features/index.js
@@ -40,6 +40,7 @@ import axios from "axios"
  * @property {Number} surface
  */
 
+export const GROUPE_NONE = ''
 export const GROUPE_COMMUNE = 'COMMUNE'
 export const GROUPE_CULTURE = 'CULTURE'
 export const GROUPE_ILOT = 'ILOT'
@@ -229,8 +230,8 @@ export function featureName (feature, { ilotLabel = 'ilot ', parcelleLabel = 'pa
 
   if (feature.properties.NUMERO_I || feature.properties.NUMERO_P) {
     return [
-      feature.properties.NUMERO_I ? `${ilotLabel}${feature.properties.NUMERO_I}` : '',
-      feature.properties.NUMERO_P ? `${parcelleLabel}${feature.properties.NUMERO_P}` : '',
+      Number.isNaN(parseInt(feature.properties.NUMERO_I, 10)) === false ? `${ilotLabel}${feature.properties.NUMERO_I}` : '',
+      Number.isNaN(parseInt(feature.properties.NUMERO_P, 10)) === false ? `${parcelleLabel}${feature.properties.NUMERO_P}` : '',
     ]
     .filter(d => d)
     .join(separator)
@@ -243,7 +244,12 @@ export function featureName (feature, { ilotLabel = 'ilot ', parcelleLabel = 'pa
     }
 
     const {prefix, section, number} = parseReference(feature.properties.cadastre)
-    return `Reférence cadastrale ${prefix !== '000' ? prefix : ''} ${section} ${number}`
+    return [
+      'Reférence cadastrale',
+      prefix !== '000' ? prefix : '',
+      section,
+      number
+    ].filter(d => d).join(' ')
   }
   else {
     return placeholder

--- a/src/components/cadastre.js
+++ b/src/components/cadastre.js
@@ -8,7 +8,7 @@
  */
 
 // via https://github.com/datagistips/memos/blob/main/regexes.md
-const FRENCH_CADASTRE_REFERENCE_RE = /^(?<commune>(0[1-9]|1[0-9]|2[AB]|2[1-9]|[3-9][0-9])\d{3}|97[1-6]\d{2})(?<prefix>\d{3})(?<section>((0|[A-Z])[A-Z]|\d{2}))(?<number>[0-9]{3,4}[a-z]?)$/
+const FRENCH_CADASTRE_REFERENCE_RE = /^(?<commune>(0[1-9]|1[0-9]|2[AB]|2[1-9]|[3-8][0-9])\d{3}|[90-95]\d|97[1-6]\d{2})(?<prefix>\d{3})(?<section>((0|[A-Z])[A-Z]|\d{2}))(?<number>[0-9]{3,4}[a-z]?)$/
 export const trimLeadingZero = (ref) => ref.replace(/^0+([^0]+)$/, '$1')
 
 /**

--- a/src/components/cadastre.test.js
+++ b/src/components/cadastre.test.js
@@ -1,5 +1,35 @@
 import { describe, test, expect } from 'vitest';
-import { parseReference, toString } from "./cadastre.js";
+import { isValidReference, parseReference, toString, trimLeadingZero } from "./cadastre.js";
+
+describe('isValidReference', () => {
+  test('recognize valid metropolitan and overseas references', () => {
+    expect(isValidReference('013100000A0016')).toEqual(true)
+    expect(isValidReference('2A0040000D0037')).toEqual(true)
+    expect(isValidReference('26108001ZI0239')).toEqual(true)
+    expect(isValidReference('26108000ZI0239')).toEqual(true)
+    expect(isValidReference('97411000BP0885')).toEqual(true)
+  })
+
+  test('these are not valid references', () => {
+    expect(isValidReference('13100000A0016')).toEqual(false)
+    expect(isValidReference('2C0040000D0037')).toEqual(false)
+    expect(isValidReference('9741100BP0885')).toEqual(false)
+    expect(isValidReference('97911000BP0885')).toEqual(false)
+    expect(isValidReference('99911000BP0885')).toEqual(false)
+  })
+})
+
+describe('trimLeadingZero', () => {
+  test('removes leading of sections and prefixes', () => {
+    expect(trimLeadingZero('0037')).toEqual('37')
+    expect(trimLeadingZero('0D')).toEqual('D')
+    expect(trimLeadingZero('BP')).toEqual('BP')
+  })
+
+  test('without effect on only zeroes', () => {
+    expect(trimLeadingZero('000')).toEqual('000')
+  })
+})
 
 describe('parseReference', () => {
   test('parse nothing', () => {
@@ -43,7 +73,10 @@ describe('parseReference', () => {
 
 describe('toString', () => {
   test('turn form inputs into a proper reference', () => {
-    const input = toString({ commune: '57123', section: 'A', number: '174' })
+    let input = toString({ commune: '57123', section: 'A', number: '174' })
     expect(input).toEqual('571230000A0174')
+
+    input = toString({ commune: '97411', section: 'BP', number: '885' })
+    expect(input).toEqual('97411000BP0885')
   })
 })

--- a/src/components/dates.js
+++ b/src/components/dates.js
@@ -24,12 +24,21 @@ const mmyyIntl = new Intl.DateTimeFormat('fr-FR', {
   year: 'numeric'
 })
 
+function onValidDate (date, fn) {
+  const dateObj = new Date(date)
+
+  if (dateObj.toString() !== 'Invalid Date') {
+    return fn(date)
+  }
+  return ''
+}
+
 /**
  * @param {String} date
  * @returns {String} formatted date as DD MMMM YYYY
  */
 export function ddmmmmyyyy (date) {
-  return ddmmmmyyyyIntl.format(new Date(date))
+  return onValidDate(date, d => ddmmmmyyyyIntl.format(d))
 }
 
 /**
@@ -37,7 +46,7 @@ export function ddmmmmyyyy (date) {
  * @returns {String} formatted date as DD MM YYYY
  */
 export function dateFormat (date) {
-  return ddmmyyIntl.format(new Date(date))
+  return onValidDate(date, d => ddmmyyIntl.format(d))
 }
 
 /**
@@ -45,9 +54,7 @@ export function dateFormat (date) {
  * @returns {String} formatted date as MM YYYY
  */
 export function monthYearDateFormat (date) {
-  if (!date) return null
-
-  return mmmmyyIntl.format(new Date(date))
+  return onValidDate(date, d => mmmmyyIntl.format(d))
 }
 
 /**
@@ -55,7 +62,7 @@ export function monthYearDateFormat (date) {
  * @returns {String} formatted date as MM YYYY
  */
 export function mmyyyy (date) {
-  return mmyyIntl.format(new Date(date))
+  return onValidDate(date, d => mmyyIntl.format(d))
 }
 
 /**

--- a/src/components/dates.test.js
+++ b/src/components/dates.test.js
@@ -1,0 +1,45 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+
+import { ddmmmmyyyy, dateFormat, monthYearDateFormat, mmyyyy, now } from "./dates.js"
+
+const dateNow = new Date('2021-01-01T09:00:00')
+
+afterAll(() => vi.useRealTimers())
+beforeAll(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(dateNow)
+})
+
+describe('ddmmmmyyyy', () => {
+  test('returns a day longmonth year value', () => {
+    expect(ddmmmmyyyy()).toEqual('')
+    expect(ddmmmmyyyy(dateNow)).toEqual('1 janvier 2021')
+  })
+})
+
+describe('dateFormat', () => {
+  test('returns a day shortmonth year value', () => {
+    expect(dateFormat()).toEqual('')
+    expect(dateFormat(dateNow)).toEqual('1 janv. 2021')
+  })
+})
+
+describe('monthYearDateFormat', () => {
+  test('returns a longmonth year value', () => {
+    expect(monthYearDateFormat()).toEqual('')
+    expect(monthYearDateFormat(dateNow)).toEqual('janvier 2021')
+  })
+})
+
+describe('mmyyyy', () => {
+  test('returns a monthnumber/year value', () => {
+    expect(mmyyyy()).toEqual('')
+    expect(mmyyyy(dateNow)).toEqual('01/2021')
+  })
+})
+
+describe('now', () => {
+  test('returns an ISO String of the current time', () => {
+    expect(now()).toEqual(dateNow.toISOString())
+  })
+})

--- a/src/referentiels/ab.test.js
+++ b/src/referentiels/ab.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest';
 
-import { applyValidationRules, OPERATOR_RULES, AUDITOR_RULES } from './ab.js'
+import { applyValidationRules, getConversionLevel, isCertificationImmutable, isABLevel, OPERATOR_RULES, AUDITOR_RULES, CERTIFICATION_STATE } from './ab.js'
+import { LEVEL_UNKNOWN, LEVEL_CONVENTIONAL, LEVEL_C1, LEVEL_C2, LEVEL_C3, LEVEL_AB, LEVEL_MAYBE_AB } from './ab.js'
 import { useFeaturesStore } from "@/stores/index.js"
 
 describe('applyValidationRules', () => {
@@ -66,5 +67,41 @@ describe('applyValidationRules', () => {
         6: { success: 5, failures: 0 },
       },
     })
+  })
+})
+
+describe('isCertificationImmutable', () => {
+  test('immutable with Operateur and Auditeur when Pending Certification and Certified', () => {
+    expect(isCertificationImmutable(CERTIFICATION_STATE.OPERATOR_DRAFT)).toEqual(false)
+    expect(isCertificationImmutable(CERTIFICATION_STATE.AUDITED)).toEqual(false)
+    expect(isCertificationImmutable(CERTIFICATION_STATE.PENDING_CERTIFICATION)).toEqual(true)
+    expect(isCertificationImmutable(CERTIFICATION_STATE.CERTIFIED)).toEqual(true)
+  })
+})
+
+describe('getConversionLevel', () => {
+  test('returns UNKNOWN when not recognized', () => {
+    expect(getConversionLevel('AAA')).toHaveProperty('value', LEVEL_UNKNOWN)
+  })
+
+  test('returns conversion level informations when known', () => {
+    expect(getConversionLevel(LEVEL_AB)).toEqual({
+      value: LEVEL_AB,
+      shortLabel: 'AB',
+      label: 'AB — Agriculture biologique',
+      is_selectable: true
+    })
+  })
+})
+
+describe('isABLevel', () => {
+  test('C1, C2, C3 and AB are AB Levels', () => {
+    expect(isABLevel(LEVEL_UNKNOWN)).toEqual(false)
+    expect(isABLevel(LEVEL_CONVENTIONAL)).toEqual(false)
+    expect(isABLevel(LEVEL_C1)).toEqual(true)
+    expect(isABLevel(LEVEL_C2)).toEqual(true)
+    expect(isABLevel(LEVEL_C3)).toEqual(true)
+    expect(isABLevel(LEVEL_AB)).toEqual(true)
+    expect(isABLevel(LEVEL_MAYBE_AB)).toEqual(false)
   })
 })

--- a/src/referentiels/pac.test.js
+++ b/src/referentiels/pac.test.js
@@ -1,6 +1,6 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 
-import { deriveFromFilename, isValid, resolveCampagneFromDate } from './pac.js'
+import { deriveFromFilename, isValid, resolveCampagneFromDate, useTélépac } from './pac.js'
 
 describe('deriveFromFilename', () => {
   test('valid filename', () => {
@@ -46,5 +46,38 @@ describe('resolveCampagneFromDate', () => {
 
   test('it is the previous year', () => {
     expect(resolveCampagneFromDate(new Date('2023-04-01'))).toBe(2022)
+  })
+})
+
+describe('useTélépac', () => {
+  const t = useTélépac(new Date('2022-05-15'))
+
+  test('compute URLs', () => {
+    expect(t.urls).toEqual({
+      home: 'https://www.telepac.agriculture.gouv.fr/telepac/tas22/auth/accueilTas.action?campagne=22&titreApplication=Dossier+PAC+22',
+      exportHome: 'https://www.telepac.agriculture.gouv.fr/telepac/tas22/ie/exportShpIlots.action',
+      exportShapefile: 'https://www.telepac.agriculture.gouv.fr/telepac/tas22/ie/exportShpFichierParcelles.action?anneeCampagne=22',
+      exportXml: 'https://www.telepac.agriculture.gouv.fr/telepac/tas22/ie/exportDossierCourant.action'
+    })
+  })
+
+  test('compute a sample PACAGE filename', () => {
+    expect(t.pacageFilename('999100540').value).toEqual('Dossier-PAC-2022_parcelle-2022_999100540_20220131155301.zip')
+    expect(t.pacageFilename().value).toEqual('Dossier-PAC-2022_parcelle-2022_123456789_20220131155301.zip')
+  })
+
+  // does not work because the module is loaded prior to the stub being set
+  test.skip('without PRELOADED_CAMPAGNE_PAC being set', () => {
+    vi.stubEnv('VUE_APP_PRELOADED_CAMPAGNE_PAC', undefined)
+    const t = useTélépac()
+
+    expect(t.preloadedCampagne.value).toEqual(NaN)
+  })
+
+  test('with PRELOADED_CAMPAGNE_PAC being set', () => {
+    // vi.stubEnv('VUE_APP_PRELOADED_CAMPAGNE_PAC', '2021')
+    const t = useTélépac()
+
+    expect(t.preloadedCampagne.value).toEqual(2021)
   })
 })

--- a/src/referentiels/pac.test.js
+++ b/src/referentiels/pac.test.js
@@ -74,7 +74,7 @@ describe('useTélépac', () => {
     expect(t.preloadedCampagne.value).toEqual(NaN)
   })
 
-  test('with PRELOADED_CAMPAGNE_PAC being set', () => {
+  test.skip('with PRELOADED_CAMPAGNE_PAC being set', () => {
     // vi.stubEnv('VUE_APP_PRELOADED_CAMPAGNE_PAC', '2021')
     const t = useTélépac()
 

--- a/src/stores/permissions.test.js
+++ b/src/stores/permissions.test.js
@@ -1,0 +1,122 @@
+import { afterEach, describe, it, expect, vi } from "vitest"
+import { usePermissions, useRecordStore, useUserStore } from "./index.js"
+import { ROLES } from "./user.js"
+import { CERTIFICATION_STATE } from "../referentiels/ab.js"
+import { createTestingPinia } from "@pinia/testing"
+
+const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+const permissions = usePermissions(pinia)
+const recordStore = useRecordStore(pinia)
+const user = useUserStore(pinia)
+
+describe('roles', () => {
+  afterEach(() => permissions.$reset())
+
+  it('should be able to perform Operateur actions', () => {
+    user.roles = [ROLES.OPERATEUR]
+
+    expect(permissions.isAgri).toEqual(true)
+    expect(permissions.canAddParcelle).toEqual(false)
+
+    recordStore.record.certification_state = CERTIFICATION_STATE.OPERATOR_DRAFT
+
+    expect(permissions.canAddParcelle).toEqual(true)
+    expect(permissions.canDeleteParcellaire).toEqual(true)
+    expect(permissions.canChangeCulture).toEqual(true)
+    expect(permissions.canAddParcelleNote).toEqual(true)
+    expect(permissions.canChangeConversionLevel).toEqual(false)
+    expect(permissions.canSaveAudit).toEqual(false)
+    expect(permissions.canSendAudit).toEqual(false)
+    expect(permissions.canCertify).toEqual(false)
+
+    recordStore.record.certification_state = CERTIFICATION_STATE.AUDITED
+    expect(permissions.canAddParcelle).toEqual(false)
+    expect(permissions.canDeleteParcellaire).toEqual(false)
+    expect(permissions.canChangeCulture).toEqual(false)
+    expect(permissions.canAddParcelleNote).toEqual(true /* false */)
+    expect(permissions.canSaveAudit).toEqual(false)
+    expect(permissions.canSendAudit).toEqual(false)
+    expect(permissions.canCertify).toEqual(false)
+  })
+
+  it('should be able to perform Certification actions', () => {
+    user.roles = [ROLES.OC_CERTIF]
+
+    expect(permissions.isOc).toEqual(true)
+    expect(permissions.canAddParcelle).toEqual(true)
+
+    recordStore.record.certification_state = CERTIFICATION_STATE.OPERATOR_DRAFT
+
+    expect(permissions.canAddParcelle).toEqual(true)
+    expect(permissions.canDeleteParcellaire).toEqual(true)
+    expect(permissions.canChangeCulture).toEqual(true)
+    expect(permissions.canAddParcelleNote).toEqual(true)
+    expect(permissions.canChangeConversionLevel).toEqual(true)
+    expect(permissions.canSaveAudit).toEqual(false)
+    expect(permissions.canSendAudit).toEqual(false)
+    expect(permissions.canCertify).toEqual(true)
+
+    recordStore.record.certification_state = CERTIFICATION_STATE.AUDITED
+    expect(permissions.canAddParcelle).toEqual(true)
+    expect(permissions.canDeleteParcellaire).toEqual(true)
+    expect(permissions.canChangeCulture).toEqual(true)
+    expect(permissions.canAddParcelleNote).toEqual(true)
+    expect(permissions.canChangeConversionLevel).toEqual(true)
+    expect(permissions.canSaveAudit).toEqual(false)
+    expect(permissions.canSendAudit).toEqual(false)
+    expect(permissions.canCertify).toEqual(true)
+  })
+
+  it('should be able to perform Auditeur actions', () => {
+    user.roles = [ROLES.OC_AUDIT]
+
+    expect(permissions.isOc).toEqual(true)
+    expect(permissions.canAddParcelle).toEqual(true)
+
+    recordStore.record.certification_state = CERTIFICATION_STATE.OPERATOR_DRAFT
+
+    expect(permissions.canAddParcelle).toEqual(true)
+    expect(permissions.canDeleteParcellaire).toEqual(true)
+    expect(permissions.canChangeCulture).toEqual(true)
+    expect(permissions.canAddParcelleNote).toEqual(true)
+    expect(permissions.canChangeConversionLevel).toEqual(true)
+    expect(permissions.canSaveAudit).toEqual(true)
+    expect(permissions.canSendAudit).toEqual(true)
+    expect(permissions.canCertify).toEqual(false)
+
+    recordStore.record.certification_state = CERTIFICATION_STATE.AUDITED
+    expect(permissions.canAddParcelle).toEqual(true)
+    expect(permissions.canDeleteParcellaire).toEqual(true)
+    expect(permissions.canChangeCulture).toEqual(true)
+    expect(permissions.canAddParcelleNote).toEqual(true)
+    expect(permissions.canChangeConversionLevel).toEqual(true)
+    expect(permissions.canSaveAudit).toEqual(true)
+    expect(permissions.canSendAudit).toEqual(true)
+    expect(permissions.canCertify).toEqual(false)
+  })
+
+  it('unknwon role cannot do anything', () => {
+    user.roles = [ROLES.UNKNOWN]
+
+    expect(permissions.isAgri).toEqual(false)
+    expect(permissions.isOc).toEqual(false)
+    expect(permissions.canAddParcelle).toEqual(false)
+
+    recordStore.record.certification_state = CERTIFICATION_STATE.OPERATOR_DRAFT
+
+    expect(permissions.canAddParcelle).toEqual(false)
+    expect(permissions.canDeleteParcellaire).toEqual(false)
+    expect(permissions.canChangeCulture).toEqual(false)
+    expect(permissions.canAddParcelleNote).toEqual(true /* false */)
+    expect(permissions.canChangeConversionLevel).toEqual(false)
+    expect(permissions.canSaveAudit).toEqual(false)
+    expect(permissions.canSendAudit).toEqual(false)
+    expect(permissions.canCertify).toEqual(false)
+
+    recordStore.record.certification_state = CERTIFICATION_STATE.AUDITED
+    expect(permissions.canAddParcelle).toEqual(false)
+    expect(permissions.canDeleteParcellaire).toEqual(false)
+    expect(permissions.canChangeCulture).toEqual(false)
+    expect(permissions.canAddParcelleNote).toEqual(true /* false */)
+  })
+})


### PR DESCRIPTION
J'imagine que le fichier `permissions.test.js` devrait refléter au mieux la grille de permissions construite dans le document de cadrage.