### PR TITLE
Remplace entièrement l'objet record en cas de navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
       "@vue/eslint-config-typescript/recommended"
     ],
     "ignorePatterns": [
+      "src/stores/record.test.js",
       "src/components/Features/FeatureGroup.test.js",
       "src/components/Features/Table.test.js"
     ],

--- a/src/main.js
+++ b/src/main.js
@@ -121,7 +121,7 @@ router.beforeEach(async (to, from) => {
   if (to.params.id || userStore.roles.includes(ROLES.OPERATEUR)) {
     const recordStore = useRecordStore()
     const record = await getOperatorParcelles(to.params.id || userStore.user.id)
-    recordStore.update(record)
+    recordStore.replace(record)
   }
 
   if (to.path === '/login/agencebio') {

--- a/src/stores/record.js
+++ b/src/stores/record.js
@@ -30,6 +30,9 @@ export const useRecordStore = defineStore('record', () => {
   })
 
   /**
+   * Soft update of a record
+   *
+   * Use case: when navigating from /parcellaire/:id to /parcellaire/:id/new-stuff
    * @param {import('@/cartobio-api').Record} updatedRecord
    */
   function update (updatedRecord) {
@@ -42,6 +45,17 @@ export const useRecordStore = defineStore('record', () => {
     if (updatedRecord.parcelles) {
       featuresStore.setAll(updatedRecord.parcelles.features)
     }
+  }
+
+  /**
+   * Replace a record with new values
+   * Use case: when navigating from /parcellaire/1234 to /parcellaire/9999 or even /parcellaires then /parcellaire/1234
+   *
+   * @param {import('@/cartobio-api').Record} maybeNewRecord
+   */
+  function replace (maybeNewRecord) {
+    reset()
+    update(maybeNewRecord)
   }
 
   function reset() {
@@ -66,8 +80,9 @@ export const useRecordStore = defineStore('record', () => {
     exists,
     isSetup,
     // methods
-    update,
+    $reset: reset,
+    replace,
     reset,
-    $reset: reset
+    update
   }
 })

--- a/src/stores/record.test.js
+++ b/src/stores/record.test.js
@@ -1,0 +1,85 @@
+import { afterEach, describe, it, expect, vi } from "vitest"
+import { useFeaturesStore, useRecordStore } from "./index.js"
+import { createTestingPinia } from "@pinia/testing"
+import record from '@/components/Features/__fixtures__/record-with-features.json' assert { type: 'json' }
+
+const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+const featuresStore = useFeaturesStore(pinia)
+const store = useRecordStore(pinia)
+
+afterEach(() => store.reset())
+
+describe('exists', () => {
+  it('does not exist by default', () => {
+    expect(store.exists).toEqual(false)
+  })
+
+  it('requires a record_id to be considered as existing', () => {
+    store.update({ operator: { id: 1, nom: 'test' }})
+    expect(store.exists).toEqual(false)
+
+    store.update(record)
+    expect(store.exists).toEqual(true)
+  })
+})
+
+describe('isSetup', () => {
+  it('does not exist by default', () => {
+    expect(store.isSetup).toEqual(false)
+  })
+
+  it('requires a record_id and an import source ', () => {
+    store.update({ record_id: 1 })
+    expect(store.isSetup).toEqual(false)
+
+    store.update(record)
+    expect(store.isSetup).toEqual(true)
+  })
+})
+
+describe('replace', () => {
+  it('does not keep track of previous data, even when it is from the same record/operator', () => {
+    store.update(record)
+    expect(store.record).toHaveProperty('record_id', '054f0d70-c3da-448f-823e-81fcf7c2bf6e')
+    expect(store.record).toHaveProperty('certification_state', 'OPERATOR_DRAFT')
+
+    store.replace({ record_id: 'newId' })
+    expect(store.record).toHaveProperty('record_id', 'newId')
+    expect(store.record).toHaveProperty('certification_state', null)
+    expect(store.record).toHaveProperty('operator', {})
+  })
+})
+
+
+describe('update', () => {
+  it('has a blank slate by default', () => {
+    expect(store.record).toHaveProperty('record_id', null)
+    expect(store.record).toHaveProperty('audit_history', [])
+  })
+
+  it('adds only known keys to the store', () => {
+    store.update({ ...record, unknownKey: true })
+    expect(store.record).toHaveProperty('record_id', record.record_id)
+    expect(store.record).not.toHaveProperty('unknownKey')
+    expect(store.record).toHaveProperty('operator', { id: 1, nom: 'test' })
+  })
+
+  it('maintains existing data if not updated', () => {
+    store.update(record)
+    store.update({ record_id: 'newId' })
+    expect(store.record).toHaveProperty('certification_state', 'OPERATOR_DRAFT')
+    expect(store.record).toHaveProperty('record_id', 'newId')
+    expect(store.record).toHaveProperty('operator', { id: 1, nom: 'test' })
+  })
+
+  it('cascades the feature store updates', () => {
+    store.update(record)
+    expect(featuresStore.all).toHaveLength(3)
+  })
+
+  it('resets the feature store as well', () => {
+    store.update(record)
+    store.reset()
+    expect(featuresStore.all).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Plutôt que _soft patcher_ les données existantes.

Ça créait des données fantômes 👻 