### PR TITLE
Utilise le formattage de nombres Excel pour l'export Certisud

### DIFF
--- a/src/components/Features/ExportStrategies/BureauVeritasExporter.js
+++ b/src/components/Features/ExportStrategies/BureauVeritasExporter.js
@@ -89,7 +89,7 @@ const getSheet = ({ featureCollection, operator }) => {
       ]
     ], { origin: `B${2 + index}`, cellDates: true });
 
-    // Formattage des totaux
+    // surface is a 2 digits figure
     sheet[`G${2 + index}`].t = 'n'
     sheet[`G${2 + index}`].z = '0.00'
   })

--- a/src/components/Features/ExportStrategies/CertisExporter.js
+++ b/src/components/Features/ExportStrategies/CertisExporter.js
@@ -135,6 +135,7 @@ const getSheet = ({ featureCollection, operator, record }) => {
   featureCollection.features.forEach((feature, index) => {
     const rowIndex = index + 8;
 
+    // surface is a 2 digits figure
     sheet[`D${rowIndex}`].t = 'n'
     sheet[`D${rowIndex}`].z = '0.00'
 

--- a/src/components/Features/ExportStrategies/CertisudExporter.js
+++ b/src/components/Features/ExportStrategies/CertisudExporter.js
@@ -6,7 +6,7 @@ import {
   GROUPE_DATE_ENGAGEMENT,
   GROUPE_NIVEAU_CONVERSION
 } from '@/components/Features/index.js'
-import BaseExporter, { generateAutresInfos, humanNumbers } from "@/components/Features/ExportStrategies/BaseExporter.js";
+import BaseExporter, { generateAutresInfos } from "@/components/Features/ExportStrategies/BaseExporter.js";
 
 const { aoa_to_sheet, book_append_sheet, book_new, sheet_add_aoa } = utils
 
@@ -51,12 +51,16 @@ const getSheet = ({ featureCollection, operator }) => {
     sheet_add_aoa(sheet, [
       [
         culture?.libelle_code_cpf ?? `[ERREUR] correspondance manquante avec ${mainKey}`,
-        humanNumbers(surface / 10_000),
+        surface / 10_000,
         autresInfos,
         features.at(0).properties.conversion_niveau ?? '',
         features.at(0).properties.engagement_date ? new Date(features.at(0).properties.engagement_date) : '',
       ]
     ], { origin: `A${2 + index}`, cellDates: true });
+
+    // surface is a 2 digits figure
+    sheet[`B${2 + index}`].t = 'n'
+    sheet[`B${2 + index}`].z = '0.00'
   })
 
   return sheet

--- a/src/components/Features/ExportStrategies/CertisudExporter.test.js
+++ b/src/components/Features/ExportStrategies/CertisudExporter.test.js
@@ -20,35 +20,39 @@ describe('CertisudExporter', () => {
       ],
       [
         'Luzerne',
-        '2,1',
+        // expect.closeTo(2.1), // in vite@5 + vitest@1
+        2.092976314534671,
         '',
         'C1',
         new Date('2023-01-01T00:00:00.000Z'),
       ],
       [
         'Luzerne',
-        '1,0',
+        // expect.closeTo(1.0), // in vite@5 + vitest@1
+        1.0464881572673355,
         '',
         'AB',
         new Date('2021-01-01T00:00:00.000Z'),
       ],
       [
         'Trèfle',
-        '1,0',
+        // expect.closeTo(1.0), // in vite@5 + vitest@1
+        1.0464881572673355,
         '4 feuilles, 2023-03-01',
         'AB',
         new Date('2021-01-01T00:00:00.000Z'),
       ],
       [
         'Trèfle',
-        '1,0',
+        // expect.closeTo(1.0), // in vite@5 + vitest@1
+        1.0464881572673355,
         '4 feuilles, 2023-03-01',
         'AB',
         new Date('2015-01-01T00:00:00.000Z'),
       ],
       [
         '[ERREUR] correspondance manquante avec 01.19.99',
-        '1,0',
+        1.0464881572673355,
         '',
         '',
         '',

--- a/src/components/Features/ExportStrategies/QualisudExporter.js
+++ b/src/components/Features/ExportStrategies/QualisudExporter.js
@@ -63,7 +63,7 @@ const getSheet = ({ featureCollection }) => {
       ]
     ], { origin: `A${rowIndex}`, cellDates: true });
 
-    // Formattage des totaux
+    // surface is a 2 digits figure
     sheet[`D${rowIndex}`].t = 'n'
     sheet[`D${rowIndex}`].z = '0.00'
     sheet[`G${rowIndex}`].t = 's'

--- a/src/components/Features/ExportStrategies/index.js
+++ b/src/components/Features/ExportStrategies/index.js
@@ -14,7 +14,7 @@ const isProduction = Boolean(import.meta.env.PROD)
 
 const exporters = new Map([
   // Use a custom exporter in development to ease testing
-  [1, isProduction ? DefaultExporter : CertisExporter],
+  [1, isProduction ? DefaultExporter : CertisudExporter],
   // Production exports
   [2, BureauVeritasExporter],
   [3, CertipaqExporter],


### PR DESCRIPTION
Quand on règle `.z`, ça a l'air d'impliquer un type `t` à `n`.

Le formattage est fait manuellement dans les exports qui sont : 

- spécifiquement en CSV
- ou qui disposent de la fonction copié/collé

C'est ça ?

Je demande, pour harmoniser la manière dont on formatte les nombres, et réduire les bugs à ce niveau.