### PR TITLE
Supprime les références à `operatorId`

### DIFF
--- a/src/cartobio-api.js
+++ b/src/cartobio-api.js
@@ -65,24 +65,34 @@ export const EventType = {
  */
 
 /**
- * @typedef {Object} StrictRecord
- * @property {string} record_id
+ * @typedef {Object} BaseRecord
+ * @property {string} certification_state
  * @property {string} created_at
+ * @property {string} numerobio
+ * @property {RecordMetadata} metadata
+ * @property {string} record_id
  * @property {string} updated_at
+ */
+
+/**
+ * @typedef {BaseRecord & {operator: Operator}} BaseRecordWithOperator
+ */
+
+/**
+ * @typedef {Object} CertificationRecord
+ * @property {string} record_id
  * @property {Array<AuditHistoryEvent>} audit_history
  * @property {string} audit_notes
  * @property {string} audit_demandes
  */
 
 /**
- * @typedef {Object} ExtendedRecord
- * @property {Operator} operator
- * @property {RecordMetadata} metadata
+ * @typedef {Object} GeographicRecord
  * @property {FeatureCollection} parcellaire
  */
 
 /**
- * @typedef {StrictRecord & ExtendedRecord} Record
+ * @typedef {BaseRecordWithOperator & CertificationRecord & GeographicRecord} Record
  */
 
 /**
@@ -104,11 +114,11 @@ export const EventType = {
 const cartobioApi = axios.create({ baseURL, timeout: 10000 })
 
 /**
- * @param {number} operatorId
+ * @param {number} numeroBio
  * @returns {Promise<Record>}
  */
-export async function getOperatorParcelles (operatorId) {
-  const { data } = await cartobioApi.get(`/v2/operator/${operatorId}`)
+export async function getOperatorParcelles (numeroBio) {
+  const { data } = await cartobioApi.get(`/v2/operator/${numeroBio}`)
 
   return data
 }
@@ -154,11 +164,11 @@ export async function fetchLatestOperators () {
 /**
  * Creates a new operator Record
  *
- * @param {{ featureCollection: GeoJSON.FeatureCollection, operatorId: number }} param0
+ * @param {{ featureCollection: GeoJSON.FeatureCollection, numeroBio: number }} param0
  * @returns {Promise<Record>}
  */
-export async function createOperatorRecord (operatorId, payload) {
-  const { data } = await cartobioApi.post(`/v2/audits/${operatorId}`, payload)
+export async function createOperatorRecord (numeroBio, payload) {
+  const { data } = await cartobioApi.post(`/v2/audits/${numeroBio}`, payload)
 
   return data
 }

--- a/src/components/Certification/OperatorSetup/index.vue
+++ b/src/components/Certification/OperatorSetup/index.vue
@@ -132,10 +132,10 @@ const setupFromTelepacModal = ref(false)
 const setupFromRPGModal = ref(false)
 
 async function handleUpload ({ geojson, source, metadata = {} }) {
-  const { id: operatorId, numeroBio, organismeCertificateur } = props.operator
+  const { numeroBio, organismeCertificateur } = props.operator
   const { id: ocId, nom: ocLabel } = organismeCertificateur
 
-  const record = await createOperatorRecord(operatorId, {
+  const record = await createOperatorRecord(numeroBio, {
     numeroBio,
     ocId,
     ocLabel,

--- a/src/components/Features/AddFlow.vue
+++ b/src/components/Features/AddFlow.vue
@@ -201,7 +201,7 @@ function nextButton() {
   }
 
   if (flowSource.value === 'dessin') {
-    return router.push({ name: 'exploitations-id-ajout-parcelle-dessin', params: { id: recordStore.record.operator.id || 1 }})
+    return router.push({ name: 'exploitations-id-ajout-parcelle-dessin', params: { id: recordStore.record.operator.numeroBio || 1 }})
   }
 }
 

--- a/src/components/Features/ExportStrategies/CertipaqExporter.js
+++ b/src/components/Features/ExportStrategies/CertipaqExporter.js
@@ -19,7 +19,7 @@ const getSheet = ({ featureCollection, operator, permissions }) => {
     ['Date de saisie :', new Date()],
   ], { cellDates: true })
 
-  sheet['B1'].l = { Target: `https://annuaire.agencebio.org/fiche/${operator.numeroBio}`, Tooltip: `https://annuaire.agencebio.org/fiche/${operator.id}` }
+  sheet['B1'].l = { Target: `https://annuaire.agencebio.org/fiche/${operator.numeroBio}`, Tooltip: `https://annuaire.agencebio.org/fiche/${operator.numeroBio}` }
   sheet['B1'].t = 's'
   sheet['B2'].t = 'd'
   sheet['B2'].z = 'dd/mm/yyyy'

--- a/src/components/Features/ExportStrategies/DefaultExporter.js
+++ b/src/components/Features/ExportStrategies/DefaultExporter.js
@@ -15,7 +15,7 @@ const getSheet = ({ featureCollection, operator, permissions }) => {
     ['Surface graphique totale (en ha) :', '', surface(featureCollection) / 10_000]
   ], { cellDates: true })
 
-  sheet['C1'].l = { Target: `https://annuaire.agencebio.org/fiche/${operator.numeroBio}`, Tooltip: `https://annuaire.agencebio.org/fiche/${operator.id}` }
+  sheet['C1'].l = { Target: `https://annuaire.agencebio.org/fiche/${operator.numeroBio}`, Tooltip: `https://annuaire.agencebio.org/fiche/${operator.numeroBio}` }
   sheet['C1'].t = 's'
   sheet['C2'].t = 'd'
   sheet['C2'].z = 'dd/mm/yyyy'

--- a/src/components/Features/FeatureGroup.vue
+++ b/src/components/Features/FeatureGroup.vue
@@ -56,7 +56,7 @@
         <div class="fr-menu" ref="actionsMenuRef" v-if="activeFeatureMenu === feature.id">
           <ul class="fr-menu__list fr-btns-group fr-btns-group--icon-left">
             <li>
-              <router-link v-if="permissions.canChangeGeometry" :to="`/exploitations/${recordStore.record.operator.id}/modifier/${feature.id}`" type="button" class="fr-btn fr-btn--tertiary-no-outline fr-icon-geometry fr-text--sm">
+              <router-link v-if="permissions.canChangeGeometry" :to="`/exploitations/${recordStore.record.operator.numeroBio}/modifier/${feature.id}`" type="button" class="fr-btn fr-btn--tertiary-no-outline fr-icon-geometry fr-text--sm">
                 Modifier le contour
               </router-link>
               <button v-else type="button" disabled class="fr-btn fr-btn--tertiary-no-outline fr-icon-geometry fr-text--sm">

--- a/src/components/Features/Table.vue
+++ b/src/components/Features/Table.vue
@@ -61,7 +61,7 @@
     </table>
 
     <p class="fr-my-3w" v-if="permissions.canAddParcelle">
-      <router-link :to="{ name: 'exploitations-id-ajout-parcelle', params: { id: operator.id || 1 }}" class="fr-btn fr-btn--secondary fr-icon--sm fr-btn--icon-left fr-icon-add-line">Ajouter une parcelle</router-link>
+      <router-link :to="{ name: 'exploitations-id-ajout-parcelle', params: { id: operator.numeroBio || 1 }}" class="fr-btn fr-btn--secondary fr-icon--sm fr-btn--icon-left fr-icon-add-line">Ajouter une parcelle</router-link>
     </p>
   </div>
 

--- a/src/components/Features/__fixtures__/record-for-exports.json
+++ b/src/components/Features/__fixtures__/record-for-exports.json
@@ -1,8 +1,8 @@
 {
   "record_id": "054f0d70-c3da-448f-823e-81fcf7c2bf6e",
   "operator": {
-    "id": 1,
     "nom": "test",
+    "numeroBio": "34857",
     "notifications": [
       {
         "id": 1,

--- a/src/components/Features/__fixtures__/record-with-features.json
+++ b/src/components/Features/__fixtures__/record-with-features.json
@@ -1,9 +1,7 @@
 {
   "record_id": "054f0d70-c3da-448f-823e-81fcf7c2bf6e",
-  "numerobio": "34857",
-  "operator_id": 1,
   "operator": {
-    "id": 1,
+    "numeroBio": "34857",
     "nom": "test"
   },
   "certification_date_debut": null,

--- a/src/components/Operator/Exploitations.vue
+++ b/src/components/Operator/Exploitations.vue
@@ -5,7 +5,7 @@
     </h2>
 
     <section class="fr-grid-row fr-grid-row--gutters" v-if="hasOperators">
-      <article class="fr-col-12 fr-col-md-4" v-for="operator in operators" :key="operator.id">
+      <article class="fr-col-12 fr-col-md-4" v-for="operator in operators" :key="operator.numeroBio">
         <div class="fr-card fr-card--horizontal">
           <div class="fr-card__body">
               <div class="fr-card__content">
@@ -32,7 +32,7 @@
                 <div class="fr-card__footer">
                   <ul class="fr-btns-group  fr-btns-group--inline-lg">
                       <li>
-                        <router-link class="fr-btn" :to="`/exploitations/${operator.id}`">
+                        <router-link class="fr-btn" :to="`/exploitations/${operator.numeroBio}`">
                           Voir cette exploitation
                         </router-link>
                       </li>

--- a/src/components/Operator/Summary.vue
+++ b/src/components/Operator/Summary.vue
@@ -1,6 +1,6 @@
 <template>
   <header class="fr-my-3w">
-    <h2 class="fr-h4 fr-my-1w" :data-operator-id="operator.id" :data-numerobio="operator.numeroBio">{{ operator.nom }}</h2>
+    <h2 class="fr-h4 fr-my-1w" :data-numerobio="operator.numeroBio">{{ operator.nom }}</h2>
 
     <p class="state fr-subtitle">
       <ParcellaireState :state="record.certification_state" :date="record.created_at" />

--- a/src/components/OperatorSetup/index.vue
+++ b/src/components/OperatorSetup/index.vue
@@ -73,14 +73,14 @@ function handleCancel () {
 }
 
 async function handleUpload () {
-  const { id: operatorId, numeroBio, organismeCertificateur } = record.operator
+  const { numeroBio, organismeCertificateur } = record.operator
   const { id: ocId, nom: ocLabel } = organismeCertificateur
 
   const geojson = toRaw(featureCollection.value)
   const source = toRaw(featureSource.value)
 
   try {
-    const record = await createOperatorRecord(operatorId, {
+    const record = await createOperatorRecord(numeroBio, {
       geojson,
       ocId,
       ocLabel,

--- a/src/pages/certification/exploitations/index.vue
+++ b/src/pages/certification/exploitations/index.vue
@@ -37,16 +37,17 @@ meta:
               <th scope="col" class="fr-text--align-right">Statut</th>
             </thead>
             <tbody>
-              <tr v-for="item in operators" :key="item.id" class="clickable" @click.stop="$router.push(`/certification/exploitations/${item.id}`)">
+              <tr v-for="{ created_at, record_id, certification_state, ...operator } in operators" :key="record_id" class="fr-enlarge-link">
                 <td>
-                  <b>{{ item.nom }}</b><br/>
-                  <span class="fr-hint-text">{{ item.commune }}, {{ item.codePostal }}</span>
+                  <router-link :to="`/certification/exploitations/${operator.numeroBio}`" class="fr-link">
+                    {{ operator.nom }}
+                  </router-link><br/>
+                  <span class="fr-hint-text">{{ operator.commune }}, {{ operator.codePostal }}</span>
                 </td>
-                <td class="fr-text--align-right">{{ monthYearDateFormat(item.dateEngagement) || '-' }}</td>
-                <td class="fr-text--align-right">
-                  <router-link :to="`/certification/exploitations/${item.id}`" class="fr-link fr-link--no-underline fr-fi-arrow-right-line fr-link--icon-right">
-                    <ParcellaireState :state="item.certification_state" :date="item.created_at" />
-                  </router-link>
+                <td class="fr-text--align-right">{{ monthYearDateFormat(operator.dateEngagement) || '-' }}</td>
+                <td class="fr-text--align-right badges">
+                  <ParcellaireState :state="certification_state" :date="created_at" />
+                  <span aria-hidden class="fr-ml-1w fr-icon-arrow-right-line fr-icon--sm" />
                 </td>
               </tr>
             </tbody>
@@ -134,10 +135,17 @@ async function doSearch () {
 }
 </script>
 
-<style>
+<style scoped>
 .fr-table table {
   display: table;
   margin-bottom: 1.5rem;
+}
+
+.fr-enlarge-link:hover {
+  background-color: var(--background-alt-blue-france-hover) !important;
+}
+.fr-enlarge-link:active {
+  background-color: var(--light-background-action-low-blue-france) !important;
 }
 
 .results-title {
@@ -147,11 +155,14 @@ async function doSearch () {
   margin-bottom: 0.5rem;
 }
 
-.fr-link--no-underline {
-  background-image: none;
+.fr-link {
+  font-weight: bold;
 }
 .fr-text--align-right {
   text-align: right !important;
+}
+.badges span {
+  vertical-align: middle;
 }
 
 [aria-disabled="true"] {

--- a/src/stores/record.test.js
+++ b/src/stores/record.test.js
@@ -15,7 +15,7 @@ describe('exists', () => {
   })
 
   it('requires a record_id to be considered as existing', () => {
-    store.update({ operator: { id: 1, nom: 'test' }})
+    store.update({ operator: { nom: 'test', numeroBio: '34857' }})
     expect(store.exists).toEqual(false)
 
     store.update(record)
@@ -61,15 +61,16 @@ describe('update', () => {
     store.update({ ...record, unknownKey: true })
     expect(store.record).toHaveProperty('record_id', record.record_id)
     expect(store.record).not.toHaveProperty('unknownKey')
-    expect(store.record).toHaveProperty('operator', { id: 1, nom: 'test' })
+    expect(store.record).toHaveProperty('operator', { nom: 'test', numeroBio: '34857' })
   })
 
   it('maintains existing data if not updated', () => {
     store.update(record)
     store.update({ record_id: 'newId' })
+    console.log(record)
     expect(store.record).toHaveProperty('certification_state', 'OPERATOR_DRAFT')
     expect(store.record).toHaveProperty('record_id', 'newId')
-    expect(store.record).toHaveProperty('operator', { id: 1, nom: 'test' })
+    expect(store.record).toHaveProperty('operator', { nom: 'test', numeroBio: '34857' })
   })
 
   it('cascades the feature store updates', () => {


### PR DESCRIPTION
- [ ] Vérifier le flow lié à `/api/v2/user/exchangeToken` (notamment la suppression de la surcharge du `userProfile` avec `operator.id` et `operator.numeroBio`

refs AgenceBio/cartobio-api#115