### PR TITLE
Sentry : tracingOrigins is deprecated

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -111,7 +111,6 @@ router.isReady().then(() => {
         integrations: [
           new Sentry.BrowserTracing({
             routingInstrumentation: Sentry.vueRouterInstrumentation(router),
-            tracingOrigins: ['cartobio.agencebio.org', 'cartobio-preprod.agencebio.org', /^.+--cartobio-dev.netlify.app$/],
           }),
         ],
         logErrors: true,


### PR DESCRIPTION
https://docs.sentry.io/platforms/javascript/guides/vue/performance/instrumentation/automatic-instrumentation/#tracepropagationtargets

The default value of tracePropagationTargets is ['localhost', /^\//]. This means that by default, tracing headers are only attached to requests that contain localhost in their URL or requests whose URL starts with a '/' (for example GET /api/v1/users).

-> Cela correspond à notre usecase, on a pas besoin de configuration particulière.