### PR TITLE
Sélectionne "En cours de traitement" par défaut lors d'une demande de réduction de conversion

### DIFF
--- a/src/components/Features/AnnotationsSelector.vue
+++ b/src/components/Features/AnnotationsSelector.vue
@@ -21,7 +21,6 @@
     <label class="fr-label" for="reduced_conversion_period_state">Information sur la dérogation</label>
 
     <select class="fr-select" name="reduced_conversion_period_state" id="reduced_conversion_period_state" :value="getMetadata(ANNOTATIONS.REDUCED_CONVERSION_PERIOD, ANNOTATIONS.METADATA_STATE)" @change="updateMetadata(ANNOTATIONS.REDUCED_CONVERSION_PERIOD, ANNOTATIONS.METADATA_STATE, $event.target.value)">
-      <option value="">Sélectionner le statut</option>
       <option :value="key" :key="key" v-for="({ label }, key) in reducedConversionStates">
         {{ label }}
       </option>

--- a/src/components/Features/SingleItemCertificationBodyForm.test.js
+++ b/src/components/Features/SingleItemCertificationBodyForm.test.js
@@ -92,6 +92,9 @@ describe("SingleItemCertificationBodyForm", () => {
     await form.find(`.fr-tags-group--annotations > .annotation--${ANNOTATIONS.REDUCED_CONVERSION_PERIOD} button`).trigger('click')
     await form.find(`.fr-tags-group--annotations > .annotation--${ANNOTATIONS.RISKY} button`).trigger('click')
 
+    expect(form.find('#reduced_conversion_period_state').element.value).toEqual(CERTIFICATION_BODY_DECISION.PENDING)
+    expect(form.find('#reduced_conversion_period_state').element.selectedOptions[0].textContent).toEqual('En cours de traitement')
+
     // we toggle and cancel the tag
     await form.find(`.fr-tags-group--annotations > .annotation--${ANNOTATIONS.SURVEYED} button`).trigger('click')
     await form.find(`.fr-tags-group--annotations > .annotation--${ANNOTATIONS.SURVEYED} button`).trigger('click')

--- a/src/components/Map/FeaturesLayer.vue
+++ b/src/components/Map/FeaturesLayer.vue
@@ -40,7 +40,7 @@ export default {
             "layout": {
               "text-field": [
                 "case",
-                ["has", "NUMERO_I"],
+                ["!=", ["to-string", ["get", "NUMERO_I"]], ""],
                 ["concat", ["get", "NUMERO_I"], ".", ["get", "NUMERO_P"]],
                 "",
               ],

--- a/src/components/Map/FeaturesLayer.vue
+++ b/src/components/Map/FeaturesLayer.vue
@@ -42,6 +42,8 @@ export default {
                 "case",
                 ["!=", ["to-string", ["get", "NUMERO_I"]], ""],
                 ["concat", ["get", "NUMERO_I"], ".", ["get", "NUMERO_P"]],
+                ["has", "NOM"],
+                ["get", "NOM"],
                 "",
               ],
               "text-font": ["Noto Sans Regular"],

--- a/src/referentiels/ab.js
+++ b/src/referentiels/ab.js
@@ -180,6 +180,7 @@ export const ANNOTATIONS = {
  * @enum {String}
  */
 export const CERTIFICATION_BODY_DECISION = {
+  PENDING: '',
   ACCEPTED: 'accepted',
   REJECTED: 'rejected'
 }
@@ -208,6 +209,9 @@ export const AnnotationTags = {
     label: 'Réduction de conversion',
     metadata: {
       [ANNOTATIONS.METADATA_STATE]: {
+        [CERTIFICATION_BODY_DECISION.PENDING]: {
+          label: 'En cours de traitement'
+        },
         [CERTIFICATION_BODY_DECISION.ACCEPTED]: {
           label: 'Dérogation acceptée'
         },


### PR DESCRIPTION
Également, sur la carte : 
- affiche un 'ilot.parcelle' si la valeur de l'ilot n'est pas vide (une valeur `null` déclenchait son affichage)
- sinon, affiche le nom de la parcelle