### PR TITLE
Les modales "Terminer l'audit" et "Certifier le parcellaire" se ferment à nouveau

### DIFF
--- a/src/components/Certification/Summary.vue
+++ b/src/components/Certification/Summary.vue
@@ -31,8 +31,8 @@
   </div>
 
   <Teleport to="body">
-    <SendOffModal :operator="operator" :record="record" v-if="showSendOffModal" v-model="showSendOffModal" @submit="handleSaveAudit" />
-    <CertificationModal :operator="operator" :record="record" v-if="showCertificationModal" v-model="showCertificationModal" @submit="handleCertify" />
+    <SendOffModal :operator="operator" :record="record" v-if="showSendOffModal" @close="showSendOffModal = false" @submit="handleSaveAudit" />
+    <CertificationModal :operator="operator" :record="record" v-if="showCertificationModal" @close="showCertificationModal = false" @submit="handleCertify" />
   </Teleport>
 </template>
 

--- a/src/components/Features/ExportStrategies/QualisudExporter.js
+++ b/src/components/Features/ExportStrategies/QualisudExporter.js
@@ -16,7 +16,7 @@ const { aoa_to_sheet, sheet_add_aoa } = utils
  * @returns {WorkSheet}
  */
 function getSheet () {
-  const { featureCollection, permissions } = this
+  const { permissions } = this
   const sheet = aoa_to_sheet([
     [
       "Production (code CPF)",

--- a/src/referentiels/ab.test.js
+++ b/src/referentiels/ab.test.js
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, describe, test, expect, vi } from 'vitest';
+import { afterAll, beforeAll, describe, test, expect, vi } from 'vitest';
 
 import { applyValidationRules, certificationDateFin, getConversionLevel, isCertificationImmutable, isABLevel, OPERATOR_RULES, AUDITOR_RULES, CERTIFICATION_STATE } from './ab.js'
 import { LEVEL_UNKNOWN, LEVEL_CONVENTIONAL, LEVEL_C1, LEVEL_C2, LEVEL_C3, LEVEL_AB, LEVEL_MAYBE_AB } from './ab.js'


### PR DESCRIPTION
Un p'tit oubli du passage du `v-model` vers le `@close`.