### PR TITLE
Unification du système de validation et de sélection de parcelles

### DIFF
--- a/src/components/ActionDropdown.vue
+++ b/src/components/ActionDropdown.vue
@@ -29,6 +29,7 @@ onClickOutside(actionsMenuRef, () => {
 .menu-container {
   position: relative;
   display: inline-block;
+  white-space: initial;
 }
 
 .fr-menu {

--- a/src/components/Certification/EngagementDateModal.vue
+++ b/src/components/Certification/EngagementDateModal.vue
@@ -11,9 +11,7 @@
     <form id="mass-edit-form" @submit.prevent="emit('submit', { ids: selectedIds, patch })">
       <div class="fr-input-group">
         <label class="fr-label">Date d'engagement</label>
-        <div class="fr-input-wrap fr-icon-calendar-line">
-          <input type="date" class="fr-input" v-model="patch.engagement_date" name="engagement_date" min="1985-01-01" :max="maxDate" required />
-        </div>
+        <input type="date" class="fr-input" v-model="patch.engagement_date" name="engagement_date" min="1985-01-01" :max="maxDate" required />
       </div>
     </form>
 

--- a/src/components/Certification/Summary.vue
+++ b/src/components/Certification/Summary.vue
@@ -63,7 +63,7 @@ const props = defineProps({
 const showSendOffModal = ref(false)
 const showCertificationModal = ref(false)
 
-const canEndAudit = computed(() => recordStore.hasFeatures && !featuresSets.hasRequiredItems)
+const canEndAudit = computed(() => recordStore.hasFeatures && !featuresSets.hasRequiredSets)
 
 async function handleSaveAudit ({ record_id: recordId, patch }) {
   let record

--- a/src/components/Certification/Summary.vue
+++ b/src/components/Certification/Summary.vue
@@ -1,23 +1,19 @@
 <template>
-  <div class="fr-alert fr-alert--warning fr-mb-3w" v-if="hasFailures">
-    <ValidationErrors :validation-result="validationResult" />
-  </div>
-
-  <div class="fr-callout fr-callout--blue-ecume" v-else-if="recordStore.hasFeatures && record.certification_state === CERTIFICATION_STATE.OPERATOR_DRAFT">
+  <div class="fr-callout fr-callout--blue-ecume" v-if="canEndAudit && record.certification_state === CERTIFICATION_STATE.OPERATOR_DRAFT">
     <h3 class="fr-callout__title">Parcellaire complet <span aria-hidden="true">🎉</span></h3>
 
     <button v-if="permissions.canSaveAudit" class="fr-btn" @click="showSendOffModal = true">Terminer l'audit</button>
     <span v-else>L'auditeur doit maintenant terminer l'audit.</span>
   </div>
 
-  <div class="fr-callout fr-callout--blue-ecume" v-else-if="record.certification_state === CERTIFICATION_STATE.AUDITED">
+  <div class="fr-callout fr-callout--blue-ecume" v-else-if="canEndAudit && record.certification_state === CERTIFICATION_STATE.AUDITED">
     <h3 class="fr-callout__title">Audit terminé</h3>
 
     <button v-if="permissions.canSendAudit" class="fr-btn" @click="handleSendAudit">Soumettre pour certification</button>
     <span v-else>L'auditeur doit maintenant soumettre l'audit pour certification.</span>
   </div>
 
-  <div class="fr-callout fr-callout--blue-ecume" v-else-if="record.certification_state === CERTIFICATION_STATE.PENDING_CERTIFICATION">
+  <div class="fr-callout fr-callout--blue-ecume" v-else-if="canEndAudit && record.certification_state === CERTIFICATION_STATE.PENDING_CERTIFICATION">
     <h3 class="fr-callout__title">Certification en cours</h3>
 
     <button v-if="permissions.canCertify" class="fr-btn" @click="showCertificationModal = true">Certifier le parcellaire</button>
@@ -38,16 +34,15 @@
 
 <script setup>
 import { computed, ref } from 'vue'
-import { applyValidationRules, CERTIFICATION_STATE } from '@/referentiels/ab.js'
+import { CERTIFICATION_STATE } from '@/referentiels/ab.js'
 import { updateAuditState } from '@/cartobio-api.js'
-import { useRecordStore } from '@/stores/index.js'
-import ValidationErrors from "@/components/Features/ValidationErrors.vue"
+import { useFeaturesSetsStore, usePermissions, useRecordStore } from '@/stores/index.js'
 import CertificationModal from "@/components/Certification/CertificationModal.vue"
 import SendOffModal from "@/components/Certification/SendOffModal.vue"
-import { usePermissions } from "@/stores/permissions.js"
 import toast from "@/components/toast.js"
 
 const recordStore = useRecordStore()
+const featuresSets = useFeaturesSetsStore()
 const permissions = usePermissions()
 
 const props = defineProps({
@@ -62,17 +57,13 @@ const props = defineProps({
   record: {
     type: Object,
     required: true
-  },
-  validationRules: {
-    type: Object,
-    required: true
   }
 })
 
 const showSendOffModal = ref(false)
 const showCertificationModal = ref(false)
-const validationResult = computed(() => applyValidationRules(props.validationRules.rules, ...props.features.features))
-const hasFailures = computed(() => Boolean(validationResult.value.failures))
+
+const canEndAudit = computed(() => recordStore.hasFeatures && !featuresSets.hasRequiredItems)
 
 async function handleSaveAudit ({ record_id: recordId, patch }) {
   let record

--- a/src/components/DesignSystem/Accordion.vue
+++ b/src/components/DesignSystem/Accordion.vue
@@ -2,7 +2,8 @@
   <section class="fr-accordion">
     <h3 class="fr-accordion__title">
       <button class="fr-accordion__btn" :aria-expanded="!isClosed" @click="handleToggle" :aria-controls="elementId" type="button">
-        {{ title }}
+        <span>{{ title }}</span>
+        <span class="fr-badge fr-badge--warning fr-badge--no-icon" v-if="requiresAction">À préciser</span>
       </button>
     </h3>
 
@@ -16,8 +17,12 @@
 import { computed, inject, nextTick, ref, watch } from 'vue'
 
 const activeAccordionId = inject('openAccordion', () => ref(null))
+
 const props = defineProps({
   open: {
+    type: Boolean
+  },
+  requiresAction: {
     type: Boolean,
     default: false
   },
@@ -35,7 +40,7 @@ const STATE = {
 
 const contentElement = ref(null)
 const elementId = ref(`accordion-${crypto.randomUUID()}`)
-const openingState = ref(props.open ? STATE.OPEN : STATE.CLOSED)
+const openingState = ref(props.open || props.requiresAction ? STATE.OPEN : STATE.CLOSED)
 
 const isClosed = computed(() => openingState.value === STATE.CLOSED)
 const isOpen = computed(() => openingState.value === STATE.OPEN)
@@ -64,5 +69,13 @@ if (activeAccordionId) {
 <style scoped>
 .fr-collapse--expanded {
   --collapse-max-height: none;
+}
+
+.fr-accordion__btn {
+  gap: 1rem;
+
+  span:first-child {
+    flex: 1;
+  }
 }
 </style>

--- a/src/components/DesignSystem/AccordionGroup.test.js
+++ b/src/components/DesignSystem/AccordionGroup.test.js
@@ -10,7 +10,14 @@ describe("AccordionGroup", () => {
   test('we trigger an edit form', async () => {
     const TestComponent = defineComponent({
       components: { AccordionGroup, AccordionSection },
-      template: '<AccordionGroup><AccordionSection title="Un"><p>1</p></AccordionSection><AccordionSection title="Deux"><p>2</p></AccordionSection></AccordionGroup>'
+      template: `<AccordionGroup>
+        <AccordionSection title="Un">
+          <p>1</p>
+        </AccordionSection>
+        <AccordionSection title="Deux">
+          <p>2</p>
+        </AccordionSection>
+      </AccordionGroup>`
     })
 
     const wrapper = mount(TestComponent)
@@ -29,6 +36,26 @@ describe("AccordionGroup", () => {
     await wrapper.findAll('.fr-accordion__btn').at(1).trigger('click')
     expect(sections.at(0).classes()).not.toContain('fr-collapse--expanded')
     expect(sections.at(1).classes()).toContain('fr-collapse--expanded')
+  })
+
+  test('we unfold a required element', async () => {
+    const TestComponent = defineComponent({
+      components: { AccordionGroup, AccordionSection },
+      template: `<AccordionGroup>
+        <AccordionSection title="Un">
+          <p>1</p>
+        </AccordionSection>
+        <AccordionSection title="Deux" requires-action>
+          <p>2</p>
+        </AccordionSection>
+      </AccordionGroup>`
+    })
+
+    const wrapper = mount(TestComponent)
+
+    // both sections should be closed
+    expect(wrapper.find('.fr-accordion:nth-child(2) .fr-collapse').classes()).toContain('fr-collapse--expanded')
+    expect(wrapper.find('.fr-accordion:nth-child(2)').text()).toContain('À préciser')
   })
 
   test('we trigger an edit form', async () => {

--- a/src/components/Features/AddFlow.vue
+++ b/src/components/Features/AddFlow.vue
@@ -110,6 +110,9 @@ const flowSource = ref('cadastre')
 const showDetailsModal = ref(false)
 const editForm = computed(() => markRaw(permissions.isOc ? CertificationBodyEditForm : OperatorEditForm))
 
+// it will be replaced server-side, but we want to go through API Schema validation
+const id = '__00000001__'
+
 // Cadastre references
 const cadastreParcelles = reactive([{ commune: '', reference: '', feature: null, error: '', key: crypto.randomUUID() }])
 const feature = ref(null)
@@ -149,7 +152,6 @@ function updateReference (index, { reference, feature: cadastreFeature }) {
 
 // Merge all cadastre references into a single feature
 watch(cadastreParcelles, () => {
-
   const features = cadastreParcelles.map(p => p.feature).filter(feature => feature !== null)
   const references = cadastreParcelles.filter(p => p.feature !== null).map(p => p.reference)
 
@@ -165,8 +167,9 @@ watch(cadastreParcelles, () => {
     multipolygon.value = features[0].geometry.type === 'MultiPolygon' && features[0].geometry.coordinates.length > 1;
     feature.value = {
       ...features[0],
-      id: 1, // it will be replaced server-side, but we want to go through API Schema validation
+      id,
       properties: {
+        id,
         cadastre: [references[0]],
         cultures: [{ CPF: '', id: crypto.randomUUID() }]
       }
@@ -182,7 +185,7 @@ watch(cadastreParcelles, () => {
   // we still set features ref even if multipolygon to allow the user to view it
   multipolygon.value = combinedFeature.geometry.type === 'MultiPolygon' && combinedFeature.geometry.coordinates.length > 1;
 
-  combinedFeature.id = 1 // it will be replaced server-side, but we want to go through API Schema validation
+  combinedFeature.id = id
   combinedFeature.properties.cadastre = references
   combinedFeature.properties.cultures = [{ CPF: '', id: crypto.randomUUID() }]
 

--- a/src/components/Features/ConversionLevelSelector.vue
+++ b/src/components/Features/ConversionLevelSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-input-group">
+  <div class="fr-input-group" :class="{'fr-input-group--error': hasErrors}">
     <label class="fr-label">Niveau de conversion</label>
 
     <div class="fr-radio-group fr-my-1w" v-for="niveau in conversionLevels" :key="niveau.value">
@@ -34,8 +34,9 @@ const props = defineProps({
   }
 })
 
-const featuresSets = useFeaturesSetsStore()
-
 const emit = defineEmits(['update:modelValue'])
+
+const featuresSets = useFeaturesSetsStore()
 const errors = computed(() => featuresSets.byFeatureProperty(props.featureId, 'conversion_niveau'))
+const hasErrors = computed(() => errors.value.size > 0)
 </script>

--- a/src/components/Features/ConversionLevelSelector.vue
+++ b/src/components/Features/ConversionLevelSelector.vue
@@ -9,19 +9,21 @@
       </label>
     </div>
 
-    <div v-if="modelValue === LEVEL_UNKNOWN" class="fr-hint-text fr-error-text">
-      Le niveau de conversion a besoin d'être indiqué.
-    </div>
-    <div v-if="modelValue === LEVEL_MAYBE_AB" class="fr-hint-text fr-error-text">
-      Le niveau de conversion en agriculture biologique a besoin d'être précisé.
+    <div v-for="([id, result]) in errors" :key="id" class="fr-hint-text fr-error-text">
+      {{ result.errorMessage }}.
     </div>
   </div>
 </template>
 
 <script setup>
-import { LEVEL_UNKNOWN, LEVEL_MAYBE_AB, userFacingConversionLevels as conversionLevels } from '@/referentiels/ab.js';
+import { computed } from 'vue'
+import { userFacingConversionLevels as conversionLevels } from '@/referentiels/ab.js'
+import { useFeaturesSetsStore } from '@/stores/index.js'
 
-defineProps({
+const props = defineProps({
+  featureId: {
+    type: String
+  },
   modelValue: {
     type: String,
     required: true
@@ -31,5 +33,9 @@ defineProps({
     default: () => false
   }
 })
+
+const featuresSets = useFeaturesSetsStore()
+
 const emit = defineEmits(['update:modelValue'])
+const errors = computed(() => featuresSets.byFeatureProperty(props.featureId, 'conversion_niveau'))
 </script>

--- a/src/components/Features/CultureSelector.vue
+++ b/src/components/Features/CultureSelector.vue
@@ -1,9 +1,6 @@
 <template>
   <fieldset class="culture-group fr-card fr-mb-1w fr-p-2w" v-for="(culture) in uuidedCultures" :key="culture.id">
-    <div class="fr-input-group">
-      <label class="fr-label" :for="`cpf-${culture.id}-input`">Type de culture</label>
-      <CultureTypeSelector :id="`cpf-${culture.id}`" :from-pac="culture.TYPE" :modelValue="culture.CPF" @update:modelValue="$CPF => updateCulture(culture.id, 'CPF', $CPF)" />
-    </div>
+    <CultureTypeSelector :feature-id="featureId" :culture="culture" :modelValue="culture.CPF" @update:modelValue="$CPF => updateCulture(culture.id, 'CPF', $CPF)" />
 
     <div class="fr-input-group">
       <label class="fr-label" :for="`variete-${culture.id}`">Variété (facultatif)</label>
@@ -42,12 +39,16 @@
 
 <script setup>
 import { computed } from 'vue'
+
 import CultureTypeSelector from './CultureTypeSelector.vue';
 
 const props = defineProps({
   cultures: {
     type: Array,
     required: true
+  },
+  featureId: {
+    type: String
   }
 })
 

--- a/src/components/Features/DeleteFeatureModal.vue
+++ b/src/components/Features/DeleteFeatureModal.vue
@@ -23,7 +23,7 @@
         <p class="fr-error-text" v-if="requiredError">Vous devez sélectionner une raison de suppression dans la liste.</p>
       </div>
 
-      <div class="fr-input-group" v-if="isOther">
+      <div class="fr-input-group">
         <label class="fr-label" for="deletion-details">
           Préciser votre motif (facultatif)
         </label>
@@ -61,7 +61,6 @@ const emit = defineEmits(['submit'])
 
 const store = useFeaturesStore()
 const feature = computed(() => store.getFeatureById(props.featureId))
-const isOther = computed(() => reason.code === DeletionReasonsCode.OTHER)
 
 const reason = reactive({
   code: '',

--- a/src/components/Features/FeatureGroup.test.js
+++ b/src/components/Features/FeatureGroup.test.js
@@ -4,15 +4,13 @@ import { createTestingPinia } from "@pinia/testing"
 import { flushPromises, mount } from "@vue/test-utils"
 
 import { GROUPE_COMMUNE, getFeatureGroups } from "@/components/Features/index.js"
-import { useRecordStore, useFeaturesStore, usePermissions } from "@/stores/index.js"
-import { OPERATOR_RULES as rules } from "@/referentiels/ab.js"
+import { useFeaturesStore, usePermissions } from "@/stores/index.js"
 
 import record from './__fixtures__/record-with-features.json' assert { type: 'json' }
 import FeatureGroup from "@/components/Features/FeatureGroup.vue"
 import EditForm from "@/components/Features/SingleItemOperatorForm.vue"
 
 const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
-const recordStore = useRecordStore(pinia)
 const featuresStore = useFeaturesStore(pinia)
 const permissions = usePermissions(pinia)
 
@@ -30,7 +28,7 @@ describe("FeatureGroup", () => {
 
   test('properly renders a group', async () => {
     const wrapper = mount(FeatureGroup, {
-      props: { featureGroup, selectedIds: [], hoveredId: null, validationRules: { rules } }
+      props: { featureGroup, selectedIds: [], hoveredId: null }
     })
     const header = wrapper.find('.intermediate-header')
 
@@ -58,7 +56,7 @@ describe("FeatureGroup", () => {
   test('non-culture grouping has different column name', async () => {
     const featureGroup = getFeatureGroups(record.parcelles, GROUPE_COMMUNE).at(0)
     const wrapper = mount(FeatureGroup, {
-      props: { featureGroup, selectedIds: [], hoveredId: null, validationRules: { rules } }
+      props: { featureGroup, selectedIds: [], hoveredId: null }
     })
     const header = wrapper.find('.intermediate-header')
     await wrapper.find('.group-header').trigger('click')
@@ -77,7 +75,7 @@ describe("FeatureGroup", () => {
 
   test('toggles on and off all group items', async () => {
     const wrapper = mount(FeatureGroup, {
-      props: { featureGroup, selectedIds: [], hoveredId: null, validationRules: { rules } }
+      props: { featureGroup, selectedIds: [], hoveredId: null }
     })
 
     expect(wrapper.vm.selectedIds).toEqual([])
@@ -107,7 +105,7 @@ describe("FeatureGroup", () => {
     })
 
     const wrapper = mount(AsyncComponent, {
-      props: { featureGroup, selectedIds: [], hoveredId: null, validationRules: { rules }, editForm: markRaw(EditForm) }
+      props: { featureGroup, selectedIds: [], hoveredId: null, editForm: markRaw(EditForm) }
     })
 
     const group = wrapper.getComponent(FeatureGroup)
@@ -119,7 +117,7 @@ describe("FeatureGroup", () => {
 
   test('we trigger a delete form', async () => {
     const wrapper = mount(FeatureGroup, {
-      props: { featureGroup, selectedIds: [], hoveredId: null, validationRules: { rules } }
+      props: { featureGroup, selectedIds: [], hoveredId: null }
     })
 
     await wrapper.find('.group-header').trigger('click')

--- a/src/components/Features/FeatureGroup.vue
+++ b/src/components/Features/FeatureGroup.vue
@@ -48,7 +48,7 @@
       </td>
       <td @click="toggleEditForm(feature.id)" class="numeric">{{ inHa(surface(feature)) }}&nbsp;ha</td>
       <td class="actions">
-        <button type="button" :class="{'fr-btn': true, 'fr-btn--tertiary-no-outline': true, 'fr-icon-edit-line': !featuresSets.byFeature(feature.id).size, 'fr-icon-edit-box-fill fr-icon--warning': featuresSets.byFeature(feature.id).size}" @click="toggleEditForm(feature.id)">
+        <button type="button" :class="{'fr-btn': true, 'fr-btn--tertiary-no-outline': true, 'fr-icon-edit-line': true /*!featuresSets.byFeature(feature.id, true).size, 'fr-icon-edit-box-fill fr-icon--warning': featuresSets.byFeature(feature.id, true).size*/}" @click="toggleEditForm(feature.id)">
           Modifier
         </button>
 
@@ -104,7 +104,7 @@ const allSelected = computed(() => featureIds.value.every(id => selectedIds.valu
 const isGroupedByCulture = computed(() => props.featureGroup.pivot === 'CULTURE')
 
 const groupErrors = computed(() => {
-  return featureIds.value.reduce((sum, id) => sum + featuresSets.byFeature(id).size, 0)
+  return featureIds.value.reduce((sum, id) => sum + featuresSets.byFeature(id, true).size, 0)
 })
 
 function toggleEditForm (featureId) {

--- a/src/components/Features/FeatureGroup.vue
+++ b/src/components/Features/FeatureGroup.vue
@@ -10,7 +10,9 @@
       <td><span class="fr-icon fr-icon-arrow-down-s-line" :aria-checked="open" aria-role="button" /></td>
       <th scope="row" colspan="2" :data-group-id="featureGroup.key">{{ featureGroup.label }}</th>
       <td class="numeric">{{ inHa(featureGroup.surface) }}&nbsp;ha</td>
-      <td class="actions"><span :class="{ 'fr-icon fr-icon-warning-fill fr-icon--warning': validation.total !== validation.success }" /></td>
+      <td class="actions">
+        <span class="fr-btn fr-btn--tertiary-no-outline fr-icon-warning-fill fr-icon--warning" :title="`${groupErrors} parcelles à amender`" v-if="groupErrors" />
+      </td>
     </tr>
     <tr :hidden="!open" class="intermediate-header">
       <th scope="col" colspan="2"></th>
@@ -46,7 +48,7 @@
       </td>
       <td @click="toggleEditForm(feature.id)" class="numeric">{{ inHa(surface(feature)) }}&nbsp;ha</td>
       <td class="actions">
-        <button type="button" :class="{'fr-btn': true, 'fr-btn--tertiary-no-outline': true, 'fr-icon-edit-line': !hasError(feature.id), 'fr-icon-edit-box-fill': hasError(feature.id), 'fr-icon--warning': hasError(feature.id)}" @click="toggleEditForm(feature.id)">
+        <button type="button" :class="{'fr-btn': true, 'fr-btn--tertiary-no-outline': true, 'fr-icon-edit-line': !featuresSets.byFeature(feature.id).size, 'fr-icon-edit-box-fill fr-icon--warning': featuresSets.byFeature(feature.id).size}" @click="toggleEditForm(feature.id)">
           Modifier
         </button>
 
@@ -69,27 +71,25 @@
 <script setup>
 import { computed, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
-import { featureName, cultureLabel, inHa, surface } from '@/components/Features/index.js'
-import { applyValidationRules } from '@/referentiels/ab.js'
-import ConversionLevel from './ConversionLevel.vue'
 import { useRoute } from "vue-router";
-import { useFeaturesStore, useOperatorStore, usePermissions, useRecordStore } from '@/stores/index.js'
+import { featureName, cultureLabel, inHa, surface } from '@/components/Features/index.js'
+import { useFeaturesStore, useFeaturesSetsStore, useOperatorStore, usePermissions, useRecordStore } from '@/stores/index.js'
+
+import ConversionLevel from './ConversionLevel.vue'
 import ActionDropdown from "@/components/ActionDropdown.vue"
+
 
 const route = useRoute()
 const operatorStore = useOperatorStore()
 const recordStore = useRecordStore()
 const featuresStore = useFeaturesStore()
+const featuresSets = useFeaturesSetsStore()
 const permissions = usePermissions()
 
 const props = defineProps({
   featureGroup: {
     type: Object,
     required: true
-  },
-  validationRules: {
-    type: Object,
-    required: true,
   }
 })
 
@@ -102,11 +102,10 @@ const featureIds = computed(() => props.featureGroup.features.map(({ id }) => id
 const open = ref(featureIds.value.includes(String(route.query?.new)))
 const allSelected = computed(() => featureIds.value.every(id => selectedIds.value.includes(id)))
 const isGroupedByCulture = computed(() => props.featureGroup.pivot === 'CULTURE')
-const validation = computed(() => applyValidationRules(props.validationRules.rules, ...props.featureGroup.features))
 
-function hasError (featureId) {
-  return validation.value.features[featureId]?.failures > 0
-}
+const groupErrors = computed(() => {
+  return featureIds.value.reduce((sum, id) => sum + featuresSets.byFeature(id).size, 0)
+})
 
 function toggleEditForm (featureId) {
   return emit('edit:featureId', featureId)

--- a/src/components/Features/FeatureGroup.vue
+++ b/src/components/Features/FeatureGroup.vue
@@ -208,6 +208,7 @@ table tr[aria-current="location"] {
 
   position: relative;
   text-align: left;
+  white-space: nowrap;
 }
 
 .fr-icon--warning {

--- a/src/components/Features/SingleItemCertificationBodyForm.test.js
+++ b/src/components/Features/SingleItemCertificationBodyForm.test.js
@@ -41,7 +41,7 @@ describe("SingleItemCertificationBodyForm", () => {
     })
 
     wrapper = mount(AsyncComponent, {
-      props: { operator, validationRules: { rules: AUDITOR_RULES }, editForm: markRaw(EditForm) }
+      props: { operator, editForm: markRaw(EditForm) }
     })
 
     const table = wrapper.getComponent(TableComponent)
@@ -72,22 +72,21 @@ describe("SingleItemCertificationBodyForm", () => {
   test("we toggle expanded annotations", async () => {
     const form = wrapper.getComponent(EditForm)
 
-    // We have 2 tags and 1 expand button
-    expect(form.findAll('.fr-tags-group--annotations > .annotation-choice')).toHaveLength(2)
-    expect(form.find('.fr-tags-group--annotations > .annotation--more').attributes()).not.toHaveProperty('hidden')
+    // We have all the tags tags and no expand button
+    expect(form.findAll('.fr-tags-group--annotations > .annotation-choice')).toHaveLength(5)
+    expect(form.find('.fr-tags-group--annotations > .annotation--more').attributes()).toHaveProperty('hidden')
 
-    await form.find('.fr-tags-group--annotations > .annotation--more button').trigger('click')
+    // expect(form.find('.fr-tags-group--annotations > .annotation--more').attributes()).not.toHaveProperty('hidden')
+    // await form.find('.fr-tags-group--annotations > .annotation--more button').trigger('click')
 
     const expectedChoices = Object.keys(AnnotationTags)
-    expect(form.find('.fr-tags-group--annotations > .annotation--more').attributes()).toHaveProperty('hidden')
     expect(form.findAll('.fr-tags-group--annotations > .annotation-choice')).toHaveLength(expectedChoices.length)
   })
 
   test("we select three choices, and two reasons", async () => {
     const form = wrapper.getComponent(EditForm)
 
-    // We have 2 tags and 1 expand button
-    await form.find('.fr-tags-group--annotations > .annotation--more button').trigger('click')
+    // We have 5 tags
     await form.find(`.fr-tags-group--annotations > .annotation--${ANNOTATIONS.DOWNGRADED} button`).trigger('click')
     await form.find(`.fr-tags-group--annotations > .annotation--${ANNOTATIONS.REDUCED_CONVERSION_PERIOD} button`).trigger('click')
     await form.find(`.fr-tags-group--annotations > .annotation--${ANNOTATIONS.RISKY} button`).trigger('click')

--- a/src/components/Features/SingleItemCertificationBodyForm.vue
+++ b/src/components/Features/SingleItemCertificationBodyForm.vue
@@ -1,26 +1,26 @@
 <template>
-  <Modal @close="showCancelModal = true" v-bind="$attrs" data-track-content data-content-name="Modale de modification de parcelle">
-    <div class="fr-card fr-p-2w fr-mb-3w">
-      <div class="fr-input-group" :class="{ 'fr-input-group--error': nameError }">
-        <label class="fr-label" for="nom">Nom de la parcelle</label>
-        <span class="fr-hint-text fr-mb-1v">Exemple&nbsp;: Les charrons 2</span>
-        <input class="fr-input fr-error" v-model="patch.NOM" :required="requiredName" :class="{ 'fr-input--error': nameError }" />
-        <p v-if="nameError" class="fr-error-text">
-          Ce champ est obligatoire
-        </p>
-      </div>
-      <p class="fr-mb-0">Sa superficie est de {{ inHa(surface(feature)) }} ha.</p>
-
-      <ul v-if="details.length">
-        <li v-for="(detail, index) in details" :key="index">
-          {{ detail }}
-        </li>
-      </ul>
-    </div>
-
+  <Modal @close="handleClose" v-bind="$attrs" data-track-content data-content-name="Modale de modification de parcelle">
     <form @submit.prevent="validate" id="single-feature-edit-form">
+      <div class="fr-card fr-p-2w fr-mb-3w">
+        <div class="fr-input-group" :class="{ 'fr-input-group--error': nameErrors.size }">
+          <label class="fr-label" for="feature-nom">Nom de la parcelle</label>
+          <span class="fr-hint-text fr-mb-1v">Exemple&nbsp;: Les charrons 2</span>
+          <input class="fr-input" id="feature-nom" v-model="patch.NOM" :required="requiredName" :class="{ 'fr-input--error': nameErrors.size }" />
+          <div v-for="([id, result]) in nameErrors" :key="id" class="fr-hint-text fr-error-text">
+            {{ result.errorMessage }}.
+          </div>
+        </div>
+        <p class="fr-mb-0">Sa superficie est de {{ inHa(surface(feature)) }} ha.</p>
+
+        <ul v-if="details.length">
+          <li v-for="(detail, index) in details" :key="index">
+            {{ detail }}
+          </li>
+        </ul>
+      </div>
+
       <AccordionGroup :constraint-toggle="!open">
-        <AccordionSection title="Culture" :open="open">
+        <AccordionSection title="Culture" :open="open" :requires-action="requiresAction(['commentaires', 'cultures'])">
           <figure class="fr-quote fr-py-1w fr-px-2w fr-my-2w" v-if="feature.properties.commentaires">
             <blockquote>
               <p>{{ feature.properties.commentaires }}</p>
@@ -30,19 +30,15 @@
             </figcaption>
           </figure>
 
-          <div class="fr-input-group">
-            <CultureSelector :feature-id="feature.properties.id" :cultures="patch.cultures" @change="$cultures => patch.cultures = $cultures" />
-          </div>
+          <CultureSelector :feature-id="feature.properties.id" :cultures="patch.cultures" @change="$cultures => patch.cultures = $cultures" />
         </AccordionSection>
 
-        <AccordionSection title="Annotations d'audit" :open="open">
+        <AccordionSection title="Annotations d'audit" :open="open" :requires-action="requiresAction(['conversion_niveau', 'engagement_date', 'annotations'])">
           <ConversionLevelSelector :feature-id="feature.properties.id" :readonly="!permissions.canChangeConversionLevel" v-model="patch.conversion_niveau" />
 
           <div class="fr-input-group" v-if="isAB">
             <label class="fr-label" for="engagement_date">Date d'engagement <span v-if="!isEngagementDateRequired">(facultatif)</span></label>
-            <div class="fr-input-wrap fr-icon-calendar-line">
-              <input type="date" class="fr-input" v-model="patch.engagement_date" name="engagement_date" id="engagement_date" :required="isEngagementDateRequired" :disabled="!isAB" min="1985-01-01" :max="maxDate" />
-            </div>
+            <input type="date" class="fr-input" v-model="patch.engagement_date" name="engagement_date" id="engagement_date" :required="isEngagementDateRequired" :disabled="!isAB" min="1985-01-01" :max="maxDate" />
           </div>
 
           <AnnotationsSelector v-if="permissions.canAddAnnotations" v-model="patch.annotations" :feature-id="feature.properties.id" />
@@ -67,12 +63,11 @@
 </template>
 
 <script setup>
-import { reactive, computed, ref } from 'vue';
+import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue';
 
 import { featureDetails, inHa, surface } from '@/components/Features/index.js'
-import { isABLevel } from '@/referentiels/ab.js'
+import { isABLevel, LEVEL_C1, LEVEL_C2, LEVEL_C3 } from '@/referentiels/ab.js'
 import { useFeaturesSetsStore, usePermissions } from '@/stores/index.js'
-import { RuleSet } from '@/stores/features-sets.js'
 import { toDateInputString } from '@/components/dates.js'
 
 import AccordionGroup from '@/components/DesignSystem/AccordionGroup.vue'
@@ -111,20 +106,19 @@ const patch = reactive({
   engagement_date: props.feature.properties.engagement_date,
   auditeur_notes: props.feature.properties.auditeur_notes || '',
 })
-const nameError = ref(false)
 
 const isAB = computed(() => isABLevel(patch.conversion_niveau))
 const maxDate = computed(() => toDateInputString(new Date()))
-const isEngagementDateRequired = computed(() => featuresSet.isRequired(RuleSet.ENGAGEMENT_DATE_MISSING))
-const details = await featureDetails(props.feature)
+const isEngagementDateRequired = computed(() => [LEVEL_C1, LEVEL_C2, LEVEL_C3].includes(patch.conversion_niveau))
+const details = featureDetails(props.feature)
+const nameErrors = computed(() => featuresSet.byFeatureProperty(props.feature.id, 'name'))
+
+function requiresAction (properties) {
+  return properties.some(property => featuresSet.byFeatureProperty(props.feature.id, property, true).size > 0)
+}
 
 const validate = () => {
-  const set = featuresSet.byFeature(props.feature.id)
-
-  if (set.has(RuleSet.NAMELESS)) {
-    nameError.value = true
-    return false
-  }
+  const set = featuresSet.byFeature(props.feature.id, true)
 
   if (set.size) {
     return false
@@ -132,6 +126,27 @@ const validate = () => {
 
   emit('submit', { id: props.feature.id, properties: patch })
 }
+
+function handleClose () {
+  if (featuresSet.isDirty) {
+    showCancelModal.value = true
+  }
+  else {
+    emit('close')
+  }
+}
+
+onBeforeUnmount(() => featuresSet.setCandidate([]))
+
+watch(patch, (properties) => {
+  featuresSet.setCandidate([{
+    id: props.feature.id,
+    properties: {
+      ...props.feature.properties,
+      ...properties
+    }
+  }])
+})
 </script>
 
 <style scoped>

--- a/src/components/Features/SingleItemOperatorForm.vue
+++ b/src/components/Features/SingleItemOperatorForm.vue
@@ -1,35 +1,32 @@
 <template>
-  <Modal @close="showCancelModal = true" v-bind="$attrs" data-track-content data-content-name="Modale de modification de parcelle">
-    <div class="fr-card fr-p-2w fr-mb-3w">
-      <div class="fr-input-group" :class="{ 'fr-input-group--error': nameError }">
-        <label class="fr-label" for="nom">Nom de la parcelle</label>
-        <span class="fr-hint-text fr-mb-1v">Exemple&nbsp;: Les charrons 2</span>
-        <input class="fr-input fr-error" v-model="patch.NOM" :required="requiredName" :class="{ 'fr-input--error': nameError }" />
-        <p v-if="nameError" class="fr-error-text">
-          Ce champ est obligatoire
-        </p>
-      </div>
-      <p class="fr-mb-0">Sa superficie est de {{ inHa(surface(feature)) }} ha.</p>
-
-      <ul v-if="details.length">
-        <li v-for="(detail, index) in details" :key="index">
-          {{ detail }}
-        </li>
-      </ul>
-    </div>
-
-
+  <Modal @close="handleClose" v-bind="$attrs" data-track-content data-content-name="Modale de modification de parcelle">
     <form @submit.prevent="validate" id="single-feature-edit-form">
-      <div v-if="permissions.canChangeCulture" class="fr-input-group">
-        <CultureSelector :cultures="patch.cultures" @change="$cultures => patch.cultures = $cultures" />
+      <div class="fr-card fr-p-2w fr-mb-3w">
+        <div class="fr-input-group" :class="{ 'fr-input-group--error': nameErrors.size }">
+          <label class="fr-label" for="feature-nom">Nom de la parcelle</label>
+          <span class="fr-hint-text fr-mb-1v">Exemple&nbsp;: Les charrons 2</span>
+          <input class="fr-input" id="feature-nom" v-model="patch.NOM" :required="requiredName" :class="{ 'fr-input--error': nameErrors.size }" />
+          <div v-for="([id, result]) in nameErrors" :key="id" class="fr-hint-text fr-error-text">
+            {{ result.errorMessage }}.
+          </div>
+        </div>
+        <p class="fr-mb-0">Sa superficie est de {{ inHa(surface(feature)) }} ha.</p>
+
+        <ul v-if="details.length">
+          <li v-for="(detail, index) in details" :key="index">
+            {{ detail }}
+          </li>
+        </ul>
       </div>
+
+      <CultureSelector v-if="permissions.canChangeCulture" :feature-id="feature.properties.id" :cultures="patch.cultures" @change="$cultures => patch.cultures = $cultures" />
 
       <div class="fr-input-group">
-        <label class="fr-label" for="commentaires">
+        <label class="fr-label" for="feature-commentaires">
           Vos notes
           <span class="fr-hint-text">Elles seront visibles par votre organisme de certification.</span>
         </label>
-        <textarea class="fr-input" id="commentaires" name="commentaires" v-model="patch.commentaires" />
+        <textarea class="fr-input" id="feature-commentaires" name="commentaires" v-model="patch.commentaires" />
       </div>
     </form>
 
@@ -46,13 +43,12 @@
 
 
 <script setup>
-import { reactive, ref } from 'vue';
+import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue';
 
 import { featureDetails, inHa, surface } from '@/components/Features/index.js'
 import Modal from '@/components/Modal.vue'
 import CultureSelector from '@/components/Features/CultureSelector.vue'
 import { useFeaturesSetsStore, usePermissions } from "@/stores/index.js"
-import { RuleSet } from "@/stores/features-sets.js"
 import CancelModal from "@/components/Forms/CancelModal.vue"
 
 const props = defineProps({
@@ -76,18 +72,39 @@ const patch = reactive({
   cultures: props.feature.properties.cultures,
   commentaires: props.feature.properties.commentaires || '',
 })
-const nameError = ref(false)
+
+const details = featureDetails(props.feature)
+const nameErrors = computed(() => featuresSet.byFeatureProperty(props.feature.id, 'name'))
 
 const validate = () => {
-  const set = featuresSet.byFeature(props.feature.id)
+  const set = featuresSet.byFeature(props.feature.id, true)
 
-  if (set.has(RuleSet.NAMELESS)) {
-    nameError.value = true
+  if (set.size) {
     return false
   }
 
   emit('submit', { id: props.feature.id, properties: patch })
 }
 
-const details = await featureDetails(props.feature)
+
+function handleClose () {
+  if (featuresSet.isDirty) {
+    showCancelModal.value = true
+  }
+  else {
+    emit('close')
+  }
+}
+
+onBeforeUnmount(() => featuresSet.setCandidate([]))
+
+watch(patch, (properties) => {
+  featuresSet.setCandidate([{
+    id: props.feature.id,
+    properties: {
+      ...props.feature.properties,
+      ...properties
+    }
+  }])
+})
 </script>

--- a/src/components/Features/SingleItemOperatorForm.vue
+++ b/src/components/Features/SingleItemOperatorForm.vue
@@ -51,8 +51,8 @@ import { reactive, ref } from 'vue';
 import { featureDetails, inHa, surface } from '@/components/Features/index.js'
 import Modal from '@/components/Modal.vue'
 import CultureSelector from '@/components/Features/CultureSelector.vue'
-import { usePermissions } from "@/stores/permissions.js"
-import { applyValidationRules, RULE_ENGAGEMENT_DATE, RULE_NAME } from "@/referentiels/ab.js"
+import { useFeaturesSetsStore, usePermissions } from "@/stores/index.js"
+import { RuleSet } from "@/stores/features-sets.js"
 import CancelModal from "@/components/Forms/CancelModal.vue"
 
 const props = defineProps({
@@ -68,6 +68,7 @@ const props = defineProps({
 const emit = defineEmits(['submit', 'close'])
 
 const permissions = usePermissions()
+const featuresSet = useFeaturesSetsStore()
 const showCancelModal = ref(false)
 
 const patch = reactive({
@@ -78,9 +79,9 @@ const patch = reactive({
 const nameError = ref(false)
 
 const validate = () => {
-  const { rules } = applyValidationRules([props.requiredName ? RULE_NAME : null, RULE_ENGAGEMENT_DATE], { properties: patch })
+  const set = featuresSet.byFeature(props.feature.id)
 
-  if (rules[RULE_NAME]?.success === 0) {
+  if (set.has(RuleSet.NAMELESS)) {
     nameError.value = true
     return false
   }

--- a/src/components/Features/Table.vue
+++ b/src/components/Features/Table.vue
@@ -65,7 +65,7 @@
         </tr>
       </tbody>
 
-      <FeatureGroup v-for="featureGroup in featureGroups" :featureGroup="featureGroup" :key="featureGroup.key" @edit:featureId="(featuredId) => editedFeatureId = featuredId" @delete:featureId="(featureId) => maybeDeletedFeatureId = featureId" :validation-rules="validationRules" />
+      <FeatureGroup v-for="featureGroup in featureGroups" :featureGroup="featureGroup" :key="featureGroup.key" @edit:featureId="(featuredId) => editedFeatureId = featuredId" @delete:featureId="(featureId) => maybeDeletedFeatureId = featureId" />
     </table>
 
     <p class="fr-my-3w" v-if="permissions.canAddParcelle">
@@ -104,10 +104,6 @@ import { statsPush } from "@/stats.js"
 defineProps({
   editForm: {
     type: Object
-  },
-  validationRules: {
-    type: Object,
-    required: true
   },
   massActions: {
     type: Array,

--- a/src/components/Features/Table.vue
+++ b/src/components/Features/Table.vue
@@ -1,8 +1,10 @@
 <template>
   <div class="fr-table fr-table--bordered fr-table--no-caption fr-my-3w">
-    <ul class="fr-tags-group fr-tags-group--annotations fr-mb-2w" v-if="permissions.canViewAnnotations">
-      <li :key="code" v-for="{ active, code, count, label } in featureAnnotations">
-        <button :class="{'fr-tag': true, 'fr-tag--dismiss': active, [`annotation--${code}`]: true }" :aria-label="`${active ? 'Retirer' : 'Ajouter'} le filtre sur étiquette ${label}`" @click="handleFilterClick(code)">{{ label }} ({{ count }})</button>
+    <ul class="fr-tags-group fr-tags-group--tags fr-mb-2w" v-if="permissions.canViewAnnotations">
+      <li :key="id" v-for="{ active, id, count, label, required } in tags">
+        <button class="fr-tag" :class="{'fr-tag--dismiss': active, [`tag--${id}`]: true, 'fr-icon-warning-fill fr-tag--icon-left': required }" :aria-label="`${active ? 'Ne plus filtrer' : 'Filtrer'} sur le critère ${label}`" @click="handleFilterClick(id)">
+          {{ label }} ({{ count }})
+        </button>
       </li>
     </ul>
 
@@ -91,7 +93,8 @@
 import { computed, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 
-import { useFeaturesStore, useOperatorStore, usePermissions, useRecordStore } from '@/stores/index.js'
+import { useFeaturesStore, useFeaturesSetsStore, useOperatorStore, usePermissions, useRecordStore } from '@/stores/index.js'
+
 import MassActionsSelector from '@/components/Features/MassActionsSelector.vue'
 import DeleteFeatureModal from '@/components/Features/DeleteFeatureModal.vue'
 import FeatureGroup from '@/components/Features/FeatureGroup.vue'
@@ -114,22 +117,23 @@ defineProps({
 const operatorStore = useOperatorStore()
 const recordStore = useRecordStore()
 const featuresStore = useFeaturesStore()
+const featuresSets = useFeaturesSetsStore()
 const permissions = usePermissions()
 
 const { operator } = storeToRefs(operatorStore)
 const { record } = storeToRefs(recordStore)
-const { hasFeatures, hits: features, annotations: featureAnnotations, hoveredId: hoveredFeatureId } = storeToRefs(featuresStore)
+const { hits: features } = storeToRefs(featuresSets)
+const { hasFeatures, hoveredId: hoveredFeatureId } = storeToRefs(featuresStore)
 const { selectedIds: selectedFeatureIds, allSelected } = storeToRefs(featuresStore)
-const { getFeatureById, toggleAllSelected, toggleAnnotation } = featuresStore
+const { getFeatureById, toggleAllSelected } = featuresStore
 
 const editedFeatureId = ref(null)
 const editedFeature = computed(() => editedFeatureId.value ? getFeatureById(editedFeatureId.value) : null)
-
 const maybeDeletedFeatureId = ref(null)
 
-const userGroupingChoice = ref('CULTURE')
+const tags = computed(() => featuresSets.tags.filter(({ active, required, count }) => (!required && count) || active))
 
-// hence, feature groups
+const userGroupingChoice = ref('CULTURE')
 const featureGroups = computed(() => getFeatureGroups({ features: features.value }, userGroupingChoice.value))
 
 const isSaving = ref(false)
@@ -137,7 +141,7 @@ const isSaving = ref(false)
 async function handleSingleFeatureSubmit ({ id, properties }) {
   statsPush(['trackEvent', 'Parcelles', 'Modification individuelle (sauvegarde)'])
 
-  featuresStore.updateMatchingFeatures([{id, properties }])
+  featuresStore.updateMatchingFeatures([{ id, properties }])
   editedFeatureId.value = null
 
   await performAsyncRecordAction(
@@ -177,11 +181,11 @@ async function handleFeatureCollectionSubmit ({ ids, patch }) {
   )
 }
 
-function handleFilterClick (code) {
-  toggleAnnotation(code)
+function handleFilterClick (id) {
+  featuresSets.toggle(id)
 
-  if (featuresStore.isAnnotationActive(code)) {
-    statsPush(['trackEvent', 'Filtre parcelles', code])
+  if (featuresSets.isToggled(id)) {
+    statsPush(['trackEvent', 'Filtre parcelles', id])
   }
 }
 
@@ -277,7 +281,7 @@ async function performAsyncRecordAction (promise, text = 'Modification enregistr
   text-align: right !important;
 }
 
-.fr-tags-group--annotations {
+.fr-tags-group--tags {
   gap: 0.75rem;
 
   > li {

--- a/src/components/Features/ValidationErrors.vue
+++ b/src/components/Features/ValidationErrors.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="fr-alert fr-alert--warning fr-mb-3w" v-if="featuresSet.hasRequiredItems">
-    <p v-for="([ruleId, result]) in featuresSet.results" :key="ruleId">
+  <div class="fr-alert fr-alert--warning fr-mb-3w" v-if="featuresSet.hasRequiredSets">
+    <p v-for="([ruleId, result]) in featuresSet.required" :key="ruleId">
       {{ result.errorMessage }} pour {{ inflex(result.count, 'parcelle', 'parcelles') }}.
 
-      <button class="fr-link fr-icon-arrow-right-line fr-link--icon-right">voir</button>
+      <button v-if="!featuresSet.isToggled(ruleId)" @click="featuresSet.toggle(ruleId)" class="fr-btn fr-btn--sm fr-btn--tertiary fr-icon-arrow-right-line fr-btn--icon-right">
+        voir
+      </button>
     </p>
   </div>
 

--- a/src/components/Features/ValidationErrors.vue
+++ b/src/components/Features/ValidationErrors.vue
@@ -1,25 +1,22 @@
 <template>
-  <p v-for="([ruleId, result]) in validationRulesWithFailures" :key="ruleId">
-    {{ ruleId === 'NOT_EMPTY' ? `Il manque un type de culture pour ${result.failures} parcelles.` : '' }}
-    {{ ruleId === 'ENGAGEMENT_DATE' ? `Il manque une date d'engagement pour ${result.failures} parcelles.` : '' }}
-    {{ ruleId === 'CONVERSION_LEVEL' ? `Il manque un niveau de conversion pour ${result.failures} parcelles.` : '' }}
-    {{ ruleId === 'MAYBE_AB' ? `Le niveau de conversion en agriculture biologique a besoin d'être précisé pour ${result.failures} parcelles.` : '' }}
-    {{ ruleId === 'CPF' ? 'Certaines cultures ont besoin d\'être précisées.' : '' }}
-  </p>
+  <div class="fr-alert fr-alert--warning fr-mb-3w" v-if="featuresSet.hasRequiredItems">
+    <p v-for="([ruleId, result]) in featuresSet.results" :key="ruleId">
+      {{ result.errorMessage }} pour {{ inflex(result.count, 'parcelle', 'parcelles') }}.
+
+      <button class="fr-link fr-icon-arrow-right-line fr-link--icon-right">voir</button>
+    </p>
+  </div>
+
 </template>
 
 <script setup>
-import { computed } from "vue"
+import { useFeaturesSetsStore } from '@/stores/index.js'
 
-const props = defineProps({
-  validationResult: {
-    type: Object,
-    required: true
-  }
-})
+const featuresSet = useFeaturesSetsStore()
+const plural = new Intl.PluralRules('fr-FR', { type: 'cardinal' })
 
-const validationRulesWithFailures = computed(() => {
-  return Object.entries(props.validationResult.rules)
-          .filter(([, { failures }]) => failures)
-})
+const inflex = (n, one, many) => {
+  const rule = plural.select(n)
+  return rule === 'one' ? `${n} ${one}` : `${n} ${many}`
+}
 </script>

--- a/src/components/Features/__fixtures__/record-with-features.json
+++ b/src/components/Features/__fixtures__/record-with-features.json
@@ -62,6 +62,7 @@
           "id": "1",
           "NOM": "parcelle 1",
           "COMMUNE": "26108",
+          "conversion_niveau": "AB",
           "cultures": [
             { "id": 1, "CPF": "01.19.10.8" }
           ]
@@ -101,6 +102,8 @@
           "id": "2",
           "NOM": "parcelle 2",
           "COMMUNE": "26108",
+          "conversion_niveau": "C3",
+          "engagement_date": "2021-01-01",
           "cultures": [
             { "id": 1, "CPF": "01.13.42", "variete": "spéciale pour ail noir" },
             { "id": 2, "CPF": "01.23.11", "surface": "0.5" }
@@ -123,6 +126,7 @@
           ],
           "NOM": "parcelle 3",
           "COMMUNE": "26113",
+          "conversion_niveau": "AB",
           "cultures": [
             { "id": 1, "CPF": "01.19.10.8" }
           ]
@@ -163,6 +167,7 @@
           "NUMERO_I": "2",
           "NUMERO_P": "1",
           "COMMUNE": "26108",
+          "conversion_niveau": "AB",
           "cultures": [
             { "id": 1, "CPF": "01.13.42", "variete": "spéciale pour ail noir" }
           ]

--- a/src/components/Features/index.js
+++ b/src/components/Features/index.js
@@ -387,22 +387,17 @@ export function featureName (feature, { ilotLabel = 'ilot ', parcelleLabel = 'pa
   }
 }
 
-export async function featureDetails (feature) {
+export function featureDetails (feature) {
   const details = []
 
   if (feature.properties.cadastre) {
     const cadastre = Array.isArray(feature.properties.cadastre) ? feature.properties.cadastre : [feature.properties.cadastre]
-    const references = cadastre
-        .map(ref => parseReference(ref))
 
-    const communes = (await Promise.all(
-        references
-        .map(({ commune }) => axios.get(`https://geo.api.gouv.fr/communes/${commune}`))
-    )).map(({ data }) => data.nom)
-
-    details.push(...references.map(
-        ({ section, number }, index) => `Parcelle cadastrale ${number} (Section ${section}, ${communes[index]})`
-    ))
+    cadastre
+      .map(ref => parseReference(ref))
+      .forEach(({ section, number }) => {
+        details.push(`Parcelle cadastrale ${number} (Section ${section}, ${feature.properties.COMMUNE_LABEL})`)
+      })
   }
 
   return details

--- a/src/components/Forms/CancelModal.vue
+++ b/src/components/Forms/CancelModal.vue
@@ -5,7 +5,7 @@ defineEmits(['close', 'cancel'])
 </script>
 
 <template>
-  <Modal @close="$emit('close')">
+  <Modal @close="$emit('close')" no-close-button>
     <template #title>Modifications non enregistrées</template>
 
     <div class="fr-alert fr-alert--warning">
@@ -24,7 +24,7 @@ defineEmits(['close', 'cancel'])
         </li>
         <li>
           <button class="fr-btn fr-btn--secondary" @click="$emit('close')">
-            Quitter
+            Annuler les modifications
           </button>
         </li>
       </ul>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -10,7 +10,7 @@
                 <slot name="title" />
               </h1>
 
-              <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="global-modal" @click="emit('close')">
+              <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="global-modal" @click="emit('close')" v-if="!noCloseButton">
                 Fermer
               </button>
             </div>
@@ -38,7 +38,8 @@ useContentTracking()
 
 const emit = defineEmits(['close'])
 defineProps({
-  icon: String
+  icon: String,
+  noCloseButton: Boolean,
 })
 
 const target = ref(null)

--- a/src/pages/exploitations/[numeroBio]/[recordId]/index.vue
+++ b/src/pages/exploitations/[numeroBio]/[recordId]/index.vue
@@ -24,12 +24,10 @@ meta:
           </p>
         </div>
 
-        <CertificationSummary v-if="permissions.isOc" :operator="operator" :record="record" :features="featureStore.collection" :validation-rules="validationRules" />
-        <div class="fr-alert fr-alert--warning fr-my-5w" v-if="permissions.isAgri && hasFailures">
-          <ValidationErrors :validation-result="validationResult" />
-        </div>
+        <CertificationSummary v-if="permissions.isOc" :operator="operator" :record="record" :features="featureStore.collection" />
+        <ValidationErrors />
 
-        <FeaturesTable :edit-form="EditForm" :validation-rules="validationRules" :mass-actions="massActions" />
+        <FeaturesTable :edit-form="EditForm" :mass-actions="massActions" />
       </div>
 
       <div class="fr-col-6 fr-col--map">
@@ -66,7 +64,7 @@ import OperatorSummary from '@/components/Operator/Summary.vue'
 import CultureTypeModal from '@/components/Operator/CultureTypeModal.vue'
 
 import { useFeaturesStore, useOperatorStore, usePermissions, useRecordStore } from "@/stores/index.js"
-import { applyValidationRules, AUDITOR_RULES, OPERATOR_RULES } from '@/referentiels/ab.js'
+
 import surroundingsStyle from "@/map-styles/surroundings.json";
 import cadastreStyle from "@/map-styles/cadastre.json";
 import ValidationErrors from "@/components/Features/ValidationErrors.vue"
@@ -92,9 +90,6 @@ const showCadastre = ref(false)
 const showIlots = ref(true)
 const isMapFullSize = ref(false)
 
-const validationRules = computed(() => ({ rules: permissions.isOc ? AUDITOR_RULES : OPERATOR_RULES }))
-const validationResult = computed(() => applyValidationRules(OPERATOR_RULES, ...featureStore.collection.features))
-const hasFailures = computed(() => Boolean(validationResult.value.failures))
 
 const EditForm = computed(() => permissions.isOc ? markRaw(SingleItemCertificationBodyForm) : markRaw(SingleItemOperatorForm))
 const massActions = computed(() => permissions.isOc ? [

--- a/src/pages/exploitations/[numeroBio]/index.vue
+++ b/src/pages/exploitations/[numeroBio]/index.vue
@@ -1,8 +1,8 @@
 <route lang="yaml">
 meta:
-requiresAuth: true
-seo:
-title: Parcellaire
+  requiresAuth: true
+  seo:
+    title: Parcellaire
 </route>
 
 <template>

--- a/src/referentiels/ab.js
+++ b/src/referentiels/ab.js
@@ -265,12 +265,15 @@ export const AnnotationTags = {
     }
   },
   [ANNOTATIONS.RISKY]: {
+    featured: () => true,
     label: 'À risque',
   },
   [ANNOTATIONS.SAMPLED]: {
+    featured: () => true,
     label: 'Prélèvement effectué'
   },
   [ANNOTATIONS.SURVEYED]: {
+    featured: () => true,
     label: 'Visitée'
   }
 }

--- a/src/referentiels/ab.test.js
+++ b/src/referentiels/ab.test.js
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, test, expect, vi } from 'vitest';
 
-import { applyValidationRules, certificationDateFin, getConversionLevel, isCertificationImmutable, isABLevel, OPERATOR_RULES, AUDITOR_RULES, CERTIFICATION_STATE } from './ab.js'
+import { certificationDateFin, getConversionLevel, isCertificationImmutable, isABLevel, CERTIFICATION_STATE } from './ab.js'
 import { LEVEL_UNKNOWN, LEVEL_CONVENTIONAL, LEVEL_C1, LEVEL_C2, LEVEL_C3, LEVEL_AB, LEVEL_MAYBE_AB } from './ab.js'
-import { useFeaturesStore } from "@/stores/index.js"
 
 const dateNow = new Date('2021-01-01T09:00:00.000+02:00')
 
@@ -10,74 +9,6 @@ afterAll(() => vi.useRealTimers())
 beforeAll(() => {
   vi.useFakeTimers()
   vi.setSystemTime(dateNow)
-})
-
-describe('applyValidationRules', () => {
-  test('operator requires culture cpf', () => {
-    const features = [
-      { id: '1', properties: { cultures: [ { TYPE: 'BTH', CPF: '01.11.12' } ] }},
-      { id: '2', properties: { cultures: [ { TYPE: '' } ] }},
-      { id: '3', properties: { cultures: [] }}
-    ]
-    const store = useFeaturesStore()
-    store.setAll(features)
-    const result = applyValidationRules([...OPERATOR_RULES, ''], ...store.collection.features)
-
-    expect(result).toEqual({
-      failures: 2,
-      success: 4,
-      total: 6,
-      features: {
-        1: { success: 2, failures: 0 },
-        2: { success: 1, failures: 1 },
-        3: { success: 1, failures: 1 }
-      },
-      rules: {
-        CPF: { success: 3, failures: 0 },
-        NOT_EMPTY: { success: 1, failures: 2 },
-      }
-    })
-  })
-
-  test('operator requires culture type, and engagement_date only if Cx', () => {
-    const features = [
-      // NOT_EMPTY not ok CPF ok
-      { id: 1, properties: { cultures: [ { TYPE: '' } ] }},
-      // below is NOT_EMPTY ok but CPF and CONVERSION_LEVEL are not
-      { id: 2, properties: { cultures: [ { TYPE: 'AGR', CPF: '01.23.11,01.23.12,01.23.13,01.23.14,01.23.19' } ] }},
-      // below is NOT_EMPTY and CPF ok, but CONVERSION_LEVEL fails
-      { id: 3, properties: { cultures: [ { TYPE: 'AIL', CPF: '01.13.42' } ], conversion_niveau: 'C1' }},
-      // below is MAYBE_AB
-      { id: 4, properties: { cultures: [ { TYPE: 'AIL', CPF: '01.13.42' } ], conversion_niveau: 'AB?' }},
-      // below are okay (CONVERSION_LEVEL succeeds)
-      { id: 5, properties: { cultures: [ { TYPE: 'AIL', CPF: '01.13.42' } ], conversion_niveau: 'AB' }},
-      { id: 6, properties: { cultures: [ { TYPE: 'AIL', CPF: '01.13.42' } ], conversion_niveau: 'C1', engagement_date: '2023-04-23' }},
-    ]
-    const store = useFeaturesStore()
-    store.setAll(features)
-    const result = applyValidationRules(AUDITOR_RULES, ...store.collection.features)
-
-    expect(result).toEqual({
-      failures: 5,
-      success: 25,
-      total: 30,
-      rules: {
-        NOT_EMPTY: { success: 5, failures: 1 },
-        CPF: { success: 5, failures: 1 },
-        MAYBE_AB: { success: 5, failures: 1 },
-        ENGAGEMENT_DATE: { success: 5, failures: 1 },
-        CONVERSION_LEVEL: { success: 5, failures: 1 },
-      },
-      features: {
-        1: { success: 4, failures: 1 },
-        2: { success: 3, failures: 2 },
-        3: { success: 4, failures: 1 },
-        4: { success: 4, failures: 1 },
-        5: { success: 5, failures: 0 },
-        6: { success: 5, failures: 0 },
-      },
-    })
-  })
 })
 
 describe('isCertificationImmutable', () => {

--- a/src/stores/features-sets.js
+++ b/src/stores/features-sets.js
@@ -1,21 +1,23 @@
-import { defineStore } from 'pinia'
-import { computed } from 'vue'
+import { defineStore, storeToRefs } from 'pinia'
+import { computed, ref, watch } from 'vue'
 import { fromCodeCpf } from "@agencebio/rosetta-cultures"
 
 import { useFeaturesStore, usePermissions } from "@/stores/index.js"
 import { AnnotationTags, LEVEL_C1, LEVEL_C2, LEVEL_C3, LEVEL_MAYBE_AB, LEVEL_UNKNOWN } from '@/referentiels/ab.js'
 import { featureName } from "@/components/Features/index.js"
 
+/** @typedef {require('geojson').Feature} Feature */
+
 /** @enum {String} */
 export const RuleSet = {
   NAMELESS: 'nameless',
-  CULTURE_MISSING: 'without-culture',
+  CULTURE_MISSING: 'culture-missing',
   CULTURE_UNSURE: 'culture-unsure',
   CONVERSION_LEVEL_MISSING: 'conversion-level-missing',
   CONVERSION_LEVEL_UNSURE: 'conversion-level-unsure',
   GEOMETRY_MISSING: 'geometry-missing',
   ENGAGEMENT_DATE_MISSING: 'engagement-date-missing',
-  ANNOTATED: 'annotated'
+  ANNOTATED: 'annotation'
 }
 
 /**
@@ -41,73 +43,104 @@ export const RuleSet = {
  * @typedef {SetItem} SetResult
  * @property {Boolean} count
  * @property {FeatureId[]} featureIds
+ * @property {<String, {Boolean|<String, Boolean>[]}>[]} details
  */
 
 export const useFeaturesSetsStore = defineStore('features-sets', () => {
   const featuresStore = useFeaturesStore()
   const permissions = usePermissions()
+  const { allCandidate, isDirty } = storeToRefs(featuresStore)
+
+  const toggles = ref(new Map())
 
   /**
    *
+   * @param {computed<Feature[]>} features
    * @param {Function(Feature): Boolean} filterFn
    * @returns {FeatureId[]}
    */
-  function collectIds (filterFn) {
-    return featuresStore.all.filter(filterFn).map(({ id }) => id)
+  function collectIds (features, filterFn) {
+    return features.value
+      .filter(f => {
+        const result = filterFn(f)
+
+        if (Array.isArray(result)) {
+          return result.some(([, result]) => result === true)
+        }
+
+        return result === true
+      })
+      .map(({ id }) => id)
+  }
+
+  /**
+   *
+   * @param {computed<Feature[]>} features
+   * @param {Function(Feature): Boolean} filterFn
+   * @returns {FeatureId[]}
+   */
+  function collectDetails (features, filterFn) {
+    return features.value
+      .flatMap(f => {
+        const result = filterFn(f)
+
+        if (Array.isArray(result)) {
+          return result.map(r => ([f.id, r])).filter(([, r]) => r.at(1))
+        }
+
+        return [ [f.id, result] ]
+      })
+      .filter(([, result]) => Array.isArray(result) ? result.length : result)
   }
 
   /** @type {Map<SetItem>} */
-  const set = new Map([
+  const definitions = computed(() => new Map([
     [
       RuleSet.NAMELESS,
       {
+        label: 'Sans nom',
         property: 'name',
         required: true,
         errorMessage: 'Il manque un nom',
-        select (name = '') {
-          return collectIds(f => featureName(f, { placeholder: '' }) === name)
+        select (f) {
+          return featureName(f, { placeholder: '' }) === ''
         }
       }
     ],
     [
       RuleSet.CULTURE_MISSING,
       {
+        label: 'Sans culture',
         property: 'cultures',
         required: true,
         errorMessage: 'Il manque un type de culture',
-        select () {
-          return collectIds(f => {
-            if (!Array.isArray(f.properties.cultures)) {
-              return true
-            }
+        select (f) {
+          if (!Array.isArray(f.properties.cultures) || f.properties.cultures.length === 0) {
+            return true
+          }
 
-            const eachHasCultureCode = f.properties.cultures.every(({ CPF }) => Boolean(CPF))
-            if (f.properties.cultures.length === 0 || eachHasCultureCode === false) {
-              return false
-            }
-          })
+          return f.properties.cultures.map(({ id, CPF, TYPE, GF }, i) => ([id ?? i, !CPF && !TYPE && !GF]))
         }
       }
     ],
     [
       RuleSet.CULTURE_UNSURE,
       {
+        label: 'Culture à préciser',
         property: 'cultures',
         required: true,
         errorMessage: 'La culture est à préciser',
-        select () {
-          return collectIds(f => {
-            if (!Array.isArray(f.properties.cultures)) {
-              return false
+        select (f) {
+          if (!Array.isArray(f.properties.cultures) || f.properties.cultures.length === 0) {
+            return false
+          }
+
+          return f.properties.cultures.map(({ id, CPF, TYPE, GF }, i) => {
+            if (!CPF && (TYPE || GF)) {
+              return [id ?? i, true]
             }
 
-            return f.properties.cultures.some(({ CPF, TYPE, GF }) => {
-              if (!CPF && (TYPE || GF)) {
-                return true
-              }
-
-              return !fromCodeCpf(CPF)?.is_selectable
-            })
+            return [id ?? i, CPF && !fromCodeCpf(CPF)?.is_selectable]
           })
         }
       }
@@ -115,52 +148,48 @@ export const useFeaturesSetsStore = defineStore('features-sets', () => {
     [
       RuleSet.CONVERSION_LEVEL_MISSING,
       {
+        label: 'Niveau de conversion manquant',
         property: 'conversion_niveau',
         required: permissions.isOc,
         errorMessage: 'Il manque un niveau de conversion',
-        select (level = LEVEL_UNKNOWN) {
-          return collectIds(f => {
-            return !f.properties.conversion_niveau || f.properties.conversion_niveau === level
-          })
+        select (f) {
+          return !f.properties.conversion_niveau || f.properties.conversion_niveau === LEVEL_UNKNOWN
         }
       }
     ],
     [
       RuleSet.CONVERSION_LEVEL_UNSURE,
       {
+        label: 'Niveau de conversion à préciser',
         property: 'conversion_niveau',
         required: permissions.isOc,
         errorMessage: 'Le niveau de conversion en agriculture biologique a besoin d\'être précisé',
-        select (level = LEVEL_MAYBE_AB) {
-          return collectIds(f => {
-            return f.properties.conversion_niveau === level
-          })
+        select (f) {
+          return f.properties.conversion_niveau === LEVEL_MAYBE_AB
         }
       }
     ],
     [
       RuleSet.ENGAGEMENT_DATE_MISSING,
       {
+        label: 'Date d\'engagement manquante',
         property: 'engagement_date',
         required: permissions.isOc,
         errorMessage: 'Il manque une date d\'engagement',
-        select () {
-          return collectIds(f => {
-            return !f.properties.engagement_date && [LEVEL_C1, LEVEL_C2, LEVEL_C3].includes(f.properties.conversion_niveau)
-          })
+        select (f) {
+          return !f.properties.engagement_date && [LEVEL_C1, LEVEL_C2, LEVEL_C3].includes(f.properties.conversion_niveau)
         }
       }
     ],
     [
       RuleSet.GEOMETRY_MISSING,
       {
+        label: 'Dessin géographique manquant',
         property: '_geometry',
         required: permissions.isOc,
         errorMessage: 'Il manque des coordonnées géométriques',
-        select () {
-          return collectIds(f => {
-            return !f.geometry || (Array.isArray(f.geometry.coordinates) && f.geometry.coordinates.length === 0)
-          })
+        select (f) {
+          return !f.geometry || (Array.isArray(f.geometry.coordinates) && f.geometry.coordinates.length === 0)
         }
       }
     ],
@@ -169,44 +198,126 @@ export const useFeaturesSetsStore = defineStore('features-sets', () => {
       {
         property: 'annotations',
         required: false,
-        select () {
-          return collectIds(f => {
-            return f.properties.annotations && Object.keys(f.properties.annotations).length > 0
-          })
+        items (features) {
+          return Array.from(features.value.reduce((map, feature) => {
+            /** @type {UserAnnotation[]} */(feature.properties.annotations ?? []).forEach(annotation => {
+              const id = [RuleSet.ANNOTATED, annotation.code].join('_')
+
+              if (!map.has(id)) {
+                map.set(id, {
+                  id,
+                  count: 0,
+                  featureIds: [],
+                  label: AnnotationTags[annotation.code].label
+                })
+              }
+
+              const stats = map.get(id)
+
+              map.set(id, {
+                ...stats,
+                count: stats.count + 1,
+                featureIds: [...stats.featureIds, feature.id]
+              })
+            })
+
+            return map
+          }, new Map()).values())
+        },
+        select (f) {
+          return f.properties.annotations && Object.keys(f.properties.annotations).length > 0
         }
       }
     ],
-  ])
+  ]))
 
   /**
-   * @type {computed<Map<SetResult>>}
+   * @type computed<Map<SetResult>>
    */
-  const results = computed(() => new Map(
-    Array.from(set.entries())
-      .map(([id, item]) => {
-        const featureIds = item.select()
+  const sets = computed(() => new Map(
+    Array.from(definitions.value.entries())
+      .map(([id, { errorMessage, label, property, required, select }]) => {
+        const featureIds = collectIds(allCandidate, select)
         return [
           id,
           {
-            ...item,
             count: featureIds.length,
-            featureIds
+            details: collectDetails(allCandidate, select),
+            errorMessage,
+            featureIds,
+            label,
+            property,
+            required
           }
         ]
       })
       .filter(([, { count }]) => count)
   ))
 
-  const hasRequiredItems = computed(() => Array.from(results.value.values()).some(({ required }) => required))
+  /**
+   * @type {computed<Map<SetResult>>}
+   */
+  const required = computed(() => new Map(
+    Array.from(sets.value.entries())
+      .filter(([, { required }]) => required)
+  ))
+
+  /**
+   * @type {computed<Map<SetResult>>}
+   */
+  const tags = computed(() => Array.from(sets.value.entries()).flatMap(([id, result]) => {
+    const definition = definitions.value.get(id)
+
+    return definition.items ? definition.items(allCandidate) : [{ id, ...result }]
+  }).map(({ id, ...item }) => ({ id, ...item, active: isToggled(id) })))
+
+  /**
+   * @type {computed<Feature[]>}
+   */
+  const hits = computed(() => {
+    const taggedFeatureIds = Array.from(tags.value.values())
+      .filter(({ active }) => active)
+      .flatMap(({ featureIds }) => featureIds)
+
+    if (!taggedFeatureIds.length) {
+      return featuresStore.all
+    }
+
+    return featuresStore.all.filter(({ id }) => taggedFeatureIds.includes(id))
+  })
+
+  function toggle (id) {
+    toggles.value.set(id, !isToggled(id))
+  }
+
+  function isToggled (id) {
+    return toggles.value.get(id) === true
+  }
+
+  /**
+   * @type {computed<Boolean>}
+   */
+  const hasRequiredSets = computed(() => required.value.size > 0)
 
   /**
    * @param {String} featureId
    * @returns {Map<SetResult>}
    */
-  function byFeature (featureId) {
+  function byFeature (featureId, filterRequired = false) {
     return new Map(
-      Array.from(results.value.entries())
-        .filter(([, { featureIds }]) => featureIds.includes(featureId))
+      Array.from(sets.value.entries())
+        .filter(([, { featureIds, required }]) => {
+          return featureIds.includes(featureId) && (filterRequired ? filterRequired && required : true)
+        })
+        .map(([key, { details, label, ...rest }]) => ([
+          key,
+          {
+            ...rest,
+            count: 1,
+            featureIds: [featureId],
+            details: details.filter((d) => d.at(0) === featureId)
+          }
+        ]))
     )
   }
 
@@ -215,46 +326,63 @@ export const useFeaturesSetsStore = defineStore('features-sets', () => {
    * @param {String} property
    * @returns {Map<SetResult>}
    */
-  function byFeatureProperty (featureId, property) {
+  function byFeatureProperty (featureId, property, filterRequired = false) {
     return new Map(
-      Array.from(results.value.entries())
-        .filter(([, { featureIds }]) => featureIds.includes(featureId))
+      Array.from(byFeature(featureId, filterRequired).entries())
         .filter(([, { property: prop }]) => prop === property)
     )
   }
 
   /**
    * @param {String} featureId
-   * @param {String} item
+   * @param {String} detailId
    * @returns {Map<SetResult>}
    */
-  function byFeatureItem (featureId, itemId) {
+  function byFeatureDetail (featureId, detailId, filterRequired = false) {
     return new Map(
-      Array.from(results.value.entries())
-        .filter(([id]) => id === itemId)
-        .filter(([, { featureIds }]) => featureIds.includes(featureId))
+      Array.from(byFeature(featureId, filterRequired).entries())
+        .filter(([, { details }]) => details.some(([fid, r]) => fid === featureId && (Array.isArray(r) ? r.at(0) === detailId : r)))
     )
   }
 
-  /**
-   * @param {String} itemId
-   * @returns {Boolean}
-   */
-  function isRequired (itemId) {
-    return Array.from(set.entries())
-      .some(([id, { required }]) => itemId === id && required)
+  function $reset () {
+    toggles.value = new Map()
   }
 
+  /*
+   * Check for toggled items with no tag (items with count=0 are out of the sets)
+   * We automatically untoggle them to avoid providing no hits and no hidden toggled tag
+   */
+  watch(tags, (currentTags) => {
+    toggles.value.forEach((value, toggledId) => {
+      const tag = currentTags.find(({ id }) => id === toggledId)
+      if (!tag && value) {
+        toggle(toggledId)
+      }
+    })
+  })
+
   return {
+    //proxy
+    isDirty,
+    setCandidate: featuresStore.setCandidate,
+    // where all lives
+    sets,
+    required, // sets filtered by requirement
     // computed
-    hasRequiredItems,
-    results,
+    hasRequiredSets,
+    tags,     // sets filtered by toggled elements
+
 
     // general methods
-    isRequired,
+    $reset,
     // per feature methods
     byFeature,
+    byFeatureDetail,
     byFeatureProperty,
-    byFeatureItem,
+    // features x active tags
+    hits,
+    isToggled,
+    toggle,
   }
 })

--- a/src/stores/features-sets.js
+++ b/src/stores/features-sets.js
@@ -341,7 +341,7 @@ export const useFeaturesSetsStore = defineStore('features-sets', () => {
   function byFeatureDetail (featureId, detailId, filterRequired = false) {
     return new Map(
       Array.from(byFeature(featureId, filterRequired).entries())
-        .filter(([, { details }]) => details.some(([fid, r]) => fid === featureId && (Array.isArray(r) ? r.at(0) === detailId : r)))
+        .filter(([, { details }]) => details.some(([fid, r]) => fid === featureId && (Array.isArray(r) ? r.at(0) === detailId : false)))
     )
   }
 

--- a/src/stores/features-sets.js
+++ b/src/stores/features-sets.js
@@ -1,0 +1,260 @@
+import { defineStore } from 'pinia'
+import { computed } from 'vue'
+import { fromCodeCpf } from "@agencebio/rosetta-cultures"
+
+import { useFeaturesStore, usePermissions } from "@/stores/index.js"
+import { AnnotationTags, LEVEL_C1, LEVEL_C2, LEVEL_C3, LEVEL_MAYBE_AB, LEVEL_UNKNOWN } from '@/referentiels/ab.js'
+import { featureName } from "@/components/Features/index.js"
+
+/** @enum {String} */
+export const RuleSet = {
+  NAMELESS: 'nameless',
+  CULTURE_MISSING: 'without-culture',
+  CULTURE_UNSURE: 'culture-unsure',
+  CONVERSION_LEVEL_MISSING: 'conversion-level-missing',
+  CONVERSION_LEVEL_UNSURE: 'conversion-level-unsure',
+  GEOMETRY_MISSING: 'geometry-missing',
+  ENGAGEMENT_DATE_MISSING: 'engagement-date-missing',
+  ANNOTATED: 'annotated'
+}
+
+/**
+ * Sets are used to "select" features, either by requiring some attention, some action or to refine results.
+ * A "Set item" is a name/selection/validation descriptor
+ * A "Set" is a set of items and a reduce function
+ * A "Set result" lists the state of each item, and which features it applies to
+ */
+
+/**
+ * @typedef {String} FeatureId
+ */
+
+/**
+ * @typedef {Object} SetItem
+ * @property {String} errorMessage
+ * @property {String?} property
+ * @property {Boolean} required
+ * @property {Function(): FeatureId[]} select
+ */
+
+/**
+ * @typedef {SetItem} SetResult
+ * @property {Boolean} count
+ * @property {FeatureId[]} featureIds
+ */
+
+export const useFeaturesSetsStore = defineStore('features-sets', () => {
+  const featuresStore = useFeaturesStore()
+  const permissions = usePermissions()
+
+  /**
+   *
+   * @param {Function(Feature): Boolean} filterFn
+   * @returns {FeatureId[]}
+   */
+  function collectIds (filterFn) {
+    return featuresStore.all.filter(filterFn).map(({ id }) => id)
+  }
+
+  /** @type {Map<SetItem>} */
+  const set = new Map([
+    [
+      RuleSet.NAMELESS,
+      {
+        property: 'name',
+        required: true,
+        errorMessage: 'Il manque un nom',
+        select (name = '') {
+          return collectIds(f => featureName(f, { placeholder: '' }) === name)
+        }
+      }
+    ],
+    [
+      RuleSet.CULTURE_MISSING,
+      {
+        property: 'cultures',
+        required: true,
+        errorMessage: 'Il manque un type de culture',
+        select () {
+          return collectIds(f => {
+            if (!Array.isArray(f.properties.cultures)) {
+              return true
+            }
+
+            const eachHasCultureCode = f.properties.cultures.every(({ CPF }) => Boolean(CPF))
+            if (f.properties.cultures.length === 0 || eachHasCultureCode === false) {
+              return false
+            }
+          })
+        }
+      }
+    ],
+    [
+      RuleSet.CULTURE_UNSURE,
+      {
+        property: 'cultures',
+        required: true,
+        errorMessage: 'La culture est à préciser',
+        select () {
+          return collectIds(f => {
+            if (!Array.isArray(f.properties.cultures)) {
+              return false
+            }
+
+            return f.properties.cultures.some(({ CPF, TYPE, GF }) => {
+              if (!CPF && (TYPE || GF)) {
+                return true
+              }
+
+              return !fromCodeCpf(CPF)?.is_selectable
+            })
+          })
+        }
+      }
+    ],
+    [
+      RuleSet.CONVERSION_LEVEL_MISSING,
+      {
+        property: 'conversion_niveau',
+        required: permissions.isOc,
+        errorMessage: 'Il manque un niveau de conversion',
+        select (level = LEVEL_UNKNOWN) {
+          return collectIds(f => {
+            return !f.properties.conversion_niveau || f.properties.conversion_niveau === level
+          })
+        }
+      }
+    ],
+    [
+      RuleSet.CONVERSION_LEVEL_UNSURE,
+      {
+        property: 'conversion_niveau',
+        required: permissions.isOc,
+        errorMessage: 'Le niveau de conversion en agriculture biologique a besoin d\'être précisé',
+        select (level = LEVEL_MAYBE_AB) {
+          return collectIds(f => {
+            return f.properties.conversion_niveau === level
+          })
+        }
+      }
+    ],
+    [
+      RuleSet.ENGAGEMENT_DATE_MISSING,
+      {
+        property: 'engagement_date',
+        required: permissions.isOc,
+        errorMessage: 'Il manque une date d\'engagement',
+        select () {
+          return collectIds(f => {
+            return !f.properties.engagement_date && [LEVEL_C1, LEVEL_C2, LEVEL_C3].includes(f.properties.conversion_niveau)
+          })
+        }
+      }
+    ],
+    [
+      RuleSet.GEOMETRY_MISSING,
+      {
+        property: '_geometry',
+        required: permissions.isOc,
+        errorMessage: 'Il manque des coordonnées géométriques',
+        select () {
+          return collectIds(f => {
+            return !f.geometry || (Array.isArray(f.geometry.coordinates) && f.geometry.coordinates.length === 0)
+          })
+        }
+      }
+    ],
+    [
+      RuleSet.ANNOTATED,
+      {
+        property: 'annotations',
+        required: false,
+        select () {
+          return collectIds(f => {
+            return f.properties.annotations && Object.keys(f.properties.annotations).length > 0
+          })
+        }
+      }
+    ],
+  ])
+
+  /**
+   * @type {computed<Map<SetResult>>}
+   */
+  const results = computed(() => new Map(
+    Array.from(set.entries())
+      .map(([id, item]) => {
+        const featureIds = item.select()
+        return [
+          id,
+          {
+            ...item,
+            count: featureIds.length,
+            featureIds
+          }
+        ]
+      })
+      .filter(([, { count }]) => count)
+  ))
+
+  const hasRequiredItems = computed(() => Array.from(results.value.values()).some(({ required }) => required))
+
+  /**
+   * @param {String} featureId
+   * @returns {Map<SetResult>}
+   */
+  function byFeature (featureId) {
+    return new Map(
+      Array.from(results.value.entries())
+        .filter(([, { featureIds }]) => featureIds.includes(featureId))
+    )
+  }
+
+  /**
+   * @param {String} featureId
+   * @param {String} property
+   * @returns {Map<SetResult>}
+   */
+  function byFeatureProperty (featureId, property) {
+    return new Map(
+      Array.from(results.value.entries())
+        .filter(([, { featureIds }]) => featureIds.includes(featureId))
+        .filter(([, { property: prop }]) => prop === property)
+    )
+  }
+
+  /**
+   * @param {String} featureId
+   * @param {String} item
+   * @returns {Map<SetResult>}
+   */
+  function byFeatureItem (featureId, itemId) {
+    return new Map(
+      Array.from(results.value.entries())
+        .filter(([id]) => id === itemId)
+        .filter(([, { featureIds }]) => featureIds.includes(featureId))
+    )
+  }
+
+  /**
+   * @param {String} itemId
+   * @returns {Boolean}
+   */
+  function isRequired (itemId) {
+    return Array.from(set.entries())
+      .some(([id, { required }]) => itemId === id && required)
+  }
+
+  return {
+    // computed
+    hasRequiredItems,
+    results,
+
+    // general methods
+    isRequired,
+    // per feature methods
+    byFeature,
+    byFeatureProperty,
+    byFeatureItem,
+  }
+})

--- a/src/stores/features-sets.test.js
+++ b/src/stores/features-sets.test.js
@@ -196,52 +196,25 @@ describe('byFeatureDetail()', () => {
   it('returns only the relevant property checks', () => {
     store.setAll(features)
 
-    expect(featuresSets.byFeatureDetail('1', '1')).toMatchObject(new Map([
+    expect(featuresSets.byFeatureDetail('2', 0)).toMatchObject(new Map([
       [
-        RuleSet.NAMELESS,
+        RuleSet.CULTURE_UNSURE,
         {
           count: 1,
-          details: [['1', true]],
-          errorMessage: 'Il manque un nom',
-          featureIds: ['1'],
-          property: 'name',
-          required: true
-        }
-      ],
-      [
-        RuleSet.CULTURE_MISSING,
-        {
-          count: 1,
-          details: [['1', true]],
-          errorMessage: "Il manque un type de culture",
-          featureIds: ['1'],
+          details: [['2', [0, true]]],
+          errorMessage: "La culture est à préciser",
+          featureIds: ['2'],
           property: 'cultures',
           required: true
         }
       ],
-      [
-        RuleSet.CONVERSION_LEVEL_MISSING,
-        {
-          count: 1,
-          details: [['1', true]],
-          errorMessage: "Il manque un niveau de conversion",
-          featureIds: ['1'],
-          property: 'conversion_niveau',
-          required: false
-        }
-      ],
-      [
-        RuleSet.GEOMETRY_MISSING,
-        {
-          count: 1,
-          details: [['1', true]],
-          errorMessage: 'Il manque des coordonnées géométriques',
-          featureIds: ['1'],
-          property: '_geometry',
-          required: false
-        }
-      ]
     ]))
+  })
+
+  it('returns an empty map if no details could be found', () => {
+    store.setAll(features)
+
+    expect(featuresSets.byFeatureDetail('1', 0)).toMatchObject(new Map())
   })
 })
 

--- a/src/stores/features-sets.test.js
+++ b/src/stores/features-sets.test.js
@@ -1,0 +1,272 @@
+import { afterEach, describe, it, expect, vi } from "vitest"
+import { flushPromises } from '@vue/test-utils'
+import { useFeaturesStore, useFeaturesSetsStore, usePermissions } from "./index.js"
+import { RuleSet } from "./features-sets.js"
+import { ANNOTATIONS } from "@/referentiels/ab.js"
+import { createTestingPinia } from "@pinia/testing"
+
+const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+const store = useFeaturesStore(pinia)
+const permissions = usePermissions(pinia)
+const featuresSets = useFeaturesSetsStore(pinia)
+
+afterEach(() => {
+  store.$reset()
+  featuresSets.$reset()
+  permissions.$reset()
+})
+
+const features = [
+  { id: "1", properties: { }},
+  { id: "2", properties: { cultures: [ { TYPE: 'AGR', CPF: '' } ] }},
+  { id: "3", properties: { cultures: [ { CPF: '01.23.11,01.23.12,01.23.13,01.23.14,01.23.19' } ] }},
+  { id: "4", properties: { NUMERO_I: '1', NUMERO_P: '2', cultures: [ { CPF: '01.13.42' } ] }},
+  { id: "5", properties: { NOM: 'test', cultures: [ { CPF: '01.13.42' } ], conversion_niveau: 'C1' }},
+  { id: "6", properties: { NOM: 'test', cultures: [ { CPF: '01.13.42' } ], conversion_niveau: 'AB?' }},
+  { id: "7", properties: { NOM: 'test', cultures: [ { CPF: '01.13.42' } ], conversion_niveau: 'AB' }},
+  { id: "8", geometry: { coordinates: [] }, properties: { NOM: 'test', cultures: [ { CPF: '01.13.42' } ], conversion_niveau: 'C1', engagement_date: '2023-04-23' }},
+]
+
+describe('results', () => {
+  it('computes an introspection of the featureCollection as an operator', () => {
+    store.setAll(features)
+
+    expect(featuresSets.sets).toMatchObject(new Map([
+      [
+        RuleSet.NAMELESS,
+        {
+          count: 3,
+          details: [['1', true], ['2', true], ['3', true]],
+          errorMessage: 'Il manque un nom',
+          featureIds: ['1', '2', '3'],
+          property: 'name',
+          required: true
+        }
+      ],
+
+      [
+        RuleSet.CULTURE_MISSING,
+        {
+          count: 1,
+          details: [['1', true]],
+          errorMessage: 'Il manque un type de culture',
+          featureIds: ['1'],
+          property: 'cultures',
+          required: true
+        }
+      ],
+
+      [
+        RuleSet.CULTURE_UNSURE,
+        {
+          count: 2,
+          details: [['2', [0, true]], ['3', [0, true]]],
+          errorMessage: 'La culture est à préciser',
+          featureIds: ['2', '3'],
+          property: 'cultures',
+          required: true
+        }
+      ],
+
+      [
+        RuleSet.CONVERSION_LEVEL_MISSING,
+        {
+          count: 4,
+          details: [['1', true], ['2', true], ['3', true], ['4', true]],
+          errorMessage: 'Il manque un niveau de conversion',
+          featureIds: ['1', '2', '3', '4'],
+          property: 'conversion_niveau',
+          required: false
+        }
+      ],
+
+      [
+        RuleSet.CONVERSION_LEVEL_UNSURE,
+        {
+          count: 1,
+          details: [['6', true]],
+          errorMessage: "Le niveau de conversion en agriculture biologique a besoin d'être précisé",
+          featureIds: ['6'],
+          property: 'conversion_niveau',
+          required: false
+        }
+      ],
+
+      [
+        RuleSet.ENGAGEMENT_DATE_MISSING,
+        {
+          count: 1,
+          details: [['5', true]],
+          errorMessage: "Il manque une date d'engagement",
+          featureIds: ['5'],
+          property: 'engagement_date',
+          required: false
+        }
+      ],
+
+      [
+        RuleSet.GEOMETRY_MISSING,
+        {
+          count: 8,
+          details: [['1', true], ['2', true], ['3', true], ['4', true], ['5', true], ['6', true], ['7', true], ['8', true]],
+          errorMessage: 'Il manque des coordonnées géométriques',
+          featureIds: ['1', '2', '3', '4', '5', '6', '7', '8'],
+          property: '_geometry',
+          required: false
+        }
+      ]
+    ]))
+  })
+
+  it('computes an introspection of the featureCollection as an OC', () => {
+    store.setAll(features)
+
+    permissions.isOc = true
+    expect(featuresSets.sets).toSatisfy((map) => map.get(RuleSet.CONVERSION_LEVEL_UNSURE).required === true)
+
+    permissions.isOc = false
+    expect(featuresSets.sets).toSatisfy((map) => map.get(RuleSet.CONVERSION_LEVEL_UNSURE).required === false)
+  })
+})
+
+describe('hasRequiredSets', () => {
+  it('tells some required checks are not fulfilled', () => {
+    store.setAll(features)
+
+    expect(featuresSets.hasRequiredSets).toBe(true)
+  })
+})
+
+describe('byFeature()', () => {
+  it('returns results tied to a featureId', () => {
+    store.setAll(features)
+
+    expect(featuresSets.byFeature('6')).toMatchObject(new Map([
+      [
+        RuleSet.CONVERSION_LEVEL_UNSURE,
+        {
+          count: 1,
+          errorMessage: "Le niveau de conversion en agriculture biologique a besoin d'être précisé",
+          featureIds: ['6'],
+          property: 'conversion_niveau',
+          required: false
+        }
+      ],
+
+      [
+        RuleSet.GEOMETRY_MISSING,
+        {
+          count: 1,
+          errorMessage: 'Il manque des coordonnées géométriques',
+          featureIds: ['6'],
+          property: '_geometry',
+          required: false
+        }
+      ]
+    ]))
+  })
+
+  it('returns nothing if a feature does not exist', () => {
+    store.setAll(features)
+
+    expect(featuresSets.byFeature('ZZZ')).toMatchObject(new Map())
+  })
+})
+
+describe('byFeatureProperty()', () => {
+  it('returns only the relevant property checks', () => {
+    store.setAll(features)
+
+    expect(featuresSets.byFeatureProperty('6', 'conversion_niveau')).toMatchObject(new Map([
+      [
+        RuleSet.CONVERSION_LEVEL_UNSURE,
+        {
+          count: 1,
+          errorMessage: "Le niveau de conversion en agriculture biologique a besoin d'être précisé",
+          featureIds: ['6'],
+          property: 'conversion_niveau',
+          required: false
+        }
+      ]
+    ]))
+  })
+})
+
+describe('byFeatureDetail()', () => {
+  it('returns only the relevant property checks', () => {
+    store.setAll(features)
+
+    expect(featuresSets.byFeatureDetail('1', '1')).toMatchObject(new Map([
+      [
+        RuleSet.NAMELESS,
+        {
+          count: 1,
+          details: [['1', true]],
+          errorMessage: 'Il manque un nom',
+          featureIds: ['1'],
+          property: 'name',
+          required: true
+        }
+      ],
+      [
+        RuleSet.CULTURE_MISSING,
+        {
+          count: 1,
+          details: [['1', true]],
+          errorMessage: "Il manque un type de culture",
+          featureIds: ['1'],
+          property: 'cultures',
+          required: true
+        }
+      ],
+      [
+        RuleSet.CONVERSION_LEVEL_MISSING,
+        {
+          count: 1,
+          details: [['1', true]],
+          errorMessage: "Il manque un niveau de conversion",
+          featureIds: ['1'],
+          property: 'conversion_niveau',
+          required: false
+        }
+      ],
+      [
+        RuleSet.GEOMETRY_MISSING,
+        {
+          count: 1,
+          details: [['1', true]],
+          errorMessage: 'Il manque des coordonnées géométriques',
+          featureIds: ['1'],
+          property: '_geometry',
+          required: false
+        }
+      ]
+    ]))
+  })
+})
+
+describe('watch/annotations', () => {
+  it('should untoggle an active filter when orphan', async () => {
+    store.setAll(features)
+
+    store.updateMatchingFeatures([{ id: '1', properties: {
+      annotations: [{ id: 1, code: ANNOTATIONS.SURVEYED }]
+    }}])
+
+    const id = [RuleSet.ANNOTATED, ANNOTATIONS.SURVEYED].join('_')
+
+    featuresSets.toggle(id)
+
+    expect(featuresSets.isToggled(id)).toEqual(true)
+    expect(featuresSets.hits).toHaveLength(1)
+
+    store.updateMatchingFeatures([{ id: '1', properties: {
+      annotations: []
+    }}])
+
+    await flushPromises()
+
+    expect(featuresSets.hits).toHaveLength(features.length)
+    expect(featuresSets.isToggled(id)).toEqual(false)
+  })
+})

--- a/src/stores/features.js
+++ b/src/stores/features.js
@@ -1,5 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref, watch } from 'vue'
+import { useFeaturesSetsStore } from "@/stores/index.js"
+
 
 /**
  * @typedef {import('@/referentiels/ab.js').UserAnnotation} UserAnnotation
@@ -18,6 +20,7 @@ export const useFeaturesStore = defineStore('features', () => {
   const selectedIds = ref([])
   const activeId = ref(null)
   const hoveredId = ref(null)
+
   /**
    * @type {reactive<CartoBioFeatureCollection>}
    */
@@ -65,7 +68,8 @@ export const useFeaturesStore = defineStore('features', () => {
    * @type {ComputedRef<CartoBioFeature[]>}
    */
   const allSelected = computed(() => {
-    const collectedIds = collectIds(collection.value.features)
+    const sets = useFeaturesSetsStore()
+    const collectedIds = collectIds(sets.hits)
 
     return collectedIds.toString() === selectedIds.value.sort().toString()
   })
@@ -107,7 +111,8 @@ export const useFeaturesStore = defineStore('features', () => {
   }
 
   function toggleAllSelected () {
-    selectedIds.value = allSelected.value ? [] : collectIds(all.value)
+    const sets = useFeaturesSetsStore()
+    selectedIds.value = allSelected.value ? [] : collectIds(sets.hits)
   }
 
   /**

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,4 +1,5 @@
 export { useFeaturesStore } from './features.js'
+export { useFeaturesSetsStore } from './features-sets.js'
 export { usePermissions } from './permissions.js'
 export { useRecordStore } from './record.js'
 export { useUserStore } from './user.js'

--- a/src/stores/record.js
+++ b/src/stores/record.js
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { computed, reactive } from 'vue'
-import { useFeaturesStore } from "@/stores/index.js"
+import { useFeaturesStore, useFeaturesSetsStore } from "@/stores/index.js"
 import bbox from '@turf/bbox'
 import { useOperatorStore } from "@/stores/operator.js"
 import { getRecord } from "@/cartobio-api.js"
@@ -11,6 +11,7 @@ import { getRecord } from "@/cartobio-api.js"
 
 export const useRecordStore = defineStore('record', () => {
   const featuresStore = useFeaturesStore()
+  const sets = useFeaturesSetsStore()
 
   const initialState = {
     record_id: null,
@@ -90,6 +91,7 @@ export const useRecordStore = defineStore('record', () => {
   function reset() {
     update({ ...initialState, metadata: { ...initialState.metadata } })
     featuresStore.$reset()
+    sets.$reset()
   }
 
   async function ready(recordId) {
@@ -108,8 +110,19 @@ export const useRecordStore = defineStore('record', () => {
   }
 
 
-    const exists = computed(() => Boolean(record.record_id))
+  /**
+   * @type {ComputedRef<Boolean>}
+   */
+  const exists = computed(() => Boolean(record.record_id))
+
+  /**
+   * @type {ComputedRef<Boolean>}
+   */
   const isSetup = computed(() => Boolean(record.record_id && 'source' in record.metadata))
+
+  /**
+   * @type {ComputedRef<Boolean>}
+   */
   const hasFeatures = computed(() => featuresStore.hasFeatures)
 
   return {


### PR DESCRIPTION
En bonus : 

- le modale Cancel s'affiche s'il y'a des changements seulement
- le champ "Raisons" s'affiche peu importe les raisons de suppression d'une parcelle
- corrige le retour à la ligne des boutons d'action (cf. d3129df)
- ⚠️ j'ai supprimé l'appel en front à l'API Geo pour obtenir le label de commune, maintenant que le backend retourne systématiquement cette info pour les parcelles (cf. c1eb62c4d40fd29a8556567254d6ba87d88e9d50)