### PR TITLE
Plein de goodies pour le sélecteur de calques

### DIFF
--- a/src/components/Map/FeaturesLayer.vue
+++ b/src/components/Map/FeaturesLayer.vue
@@ -4,7 +4,7 @@
 <script>
 import GeojsonLayer from "@/components/Map/GeojsonLayer.vue"
 import { useFeaturesStore } from "@/stores/index.js"
-import { inject, watch } from "vue"
+import { inject } from "vue"
 
 export default {
   extends: GeojsonLayer,
@@ -24,13 +24,9 @@ export default {
       type: Boolean,
       default: false
     },
-    showNumerosIlots: {
-      type: Boolean,
-      default: false
-    },
     style: {
       type: Object,
-      default: (props) => ({
+      default: () => ({
         layers: [
           {
             "id": "numeros-ilots",
@@ -48,7 +44,7 @@ export default {
               ],
               "text-font": ["Noto Sans Regular"],
               "text-size": 12,
-              "visibility": props.showNumeroIlots ? "visible" : "none",
+              "visibility": "visible",
             },
             "paint": {
               "text-color": "rgba(0, 0, 0, 1)",
@@ -64,17 +60,6 @@ export default {
   setup(props) {
     const featureStore = useFeaturesStore()
     const map = inject('map')
-
-    watch(() => props.showNumerosIlots, (showNumeroIlots) => {
-      const visibility = showNumeroIlots ? 'visible' : 'none'
-
-      if (map.value.isStyleLoaded()) {
-        map.value.setLayoutProperty('parcellaire-operateur/numeros-ilots', 'visibility', visibility)
-      }
-      else {
-        map.value.once('load', () => map.value.setLayoutProperty('parcellaire-operateur/numeros-ilots', 'visibility', visibility))
-      }
-    }, { immediate: true })
 
     if (props.interactive) {
       featureStore.bindMaplibreFeatureState(map.value, 'parcellaire-operateur/data')

--- a/src/components/Map/GeojsonLayer.vue
+++ b/src/components/Map/GeojsonLayer.vue
@@ -18,6 +18,7 @@ export default {
     before: {
       type: String,
       required: false,
+      default: 'waterway-name'
     },
     fill: {
       type: Object,
@@ -48,68 +49,76 @@ export default {
   },
   inject: ['map'],
   mounted() {
-    // always create the data layer even if data is empty at first,
-    // otherwise the watch() fails (if empty at first, it cannot be updated)
-    this.map
-      .addSource(`${this.name}/data`, {
-        type: 'geojson',
-        data: this.data ?? { type: 'FeatureCollection', features: [] }
-      })
+    this.map.once('data', () => {
+      const nextLayer = this.map.getLayersOrder().find((id) => this.before === id.split('/')[0])
 
-    // If we use a data and fill / line props, we create the geometry layers
-    if (this.data && this.fill && !this.map.getLayer(`${this.name}/geometry`)) {
-      this.map.addLayer({
-        id: `${this.name}/geometry`,
-        source: `${this.name}/data`,
-        type: 'fill',
-        paint: this.fill
-      })
-    }
-
-    if (this.data && this.line && !this.map.getLayer(`${this.name}/geometry-outline`)) {
-      this.map.addLayer({
-        id: `${this.name}/geometry-outline`,
-        source: `${this.name}/data`,
-        type: 'line',
-        paint: this.line
-      })
-    }
-
-    // If we use a style prop, we create the layers
-    if (!this.style) return
-
-    if (this.style.sprite) {
-      const hasSprite = !this.map
-          .getStyle?.()
-          ?.sprite
-          ?.find(({ id, url }) => id === this.name || url === this.style.sprite)
-      if (!hasSprite) {
-        this.map.addSprite(this.name, this.style.sprite)
+      // always create the data layer even if data is empty at first,
+      // otherwise the watch() fails (if empty at first, it cannot be updated)
+      if (!this.map.getSource(`${this.name}/data`)) {
+        this.map
+        .addSource(`${this.name}/data`, {
+          type: 'geojson',
+          data: this.data ?? { type: 'FeatureCollection', features: [] }
+        })
       }
-    }
 
-    if (this.style.glyphs) {
-      this.map.setGlyphs(this.style.glyphs)
-    }
+      // If we use a data and fill / line props, we create the geometry layers
+      if (this.data && this.fill && !this.map.getLayer(`${this.name}/geometry`)) {
+        this.map.addLayer({
+          id: `${this.name}/geometry`,
+          source: `${this.name}/data`,
+          type: 'fill',
+          paint: this.fill
+        }, nextLayer)
+      }
 
-    Object.entries(this.style.sources || {}).map(([key, value]) => {
-      if (this.map.style && this.map.getSource(`${this.name}/${key}`)) return
-      this.map.addSource(`${this.name}/${key}`, value)
-    })
+      if (this.data && this.line && !this.map.getLayer(`${this.name}/geometry-outline`)) {
+        this.map.addLayer({
+          id: `${this.name}/geometry-outline`,
+          source: `${this.name}/data`,
+          type: 'line',
+          paint: this.line
+        }, nextLayer)
+      }
 
-    this.style.layers?.map(layer => {
-      if (this.map.getLayer(layer.id)) return
+      // If we use a style prop, we create the layers
+      if (!this.style) return
 
-      const nextLayer = this.map.getStyle().layers.find(({ id }) => this.before === id.split('/')[0])
-      this.map.addLayer({
-        ...layer,
-        id: `${this.name}/${layer.id}`,
-        source: `${this.name}/${layer.source}`
-      }, nextLayer?.id)
+      if (this.style.sprite) {
+        const hasSprite = this.map.getSprite(this.name)
+
+        if (!hasSprite) {
+          this.map.addSprite(this.name, this.style.sprite)
+        }
+      }
+
+      if (this.style.glyphs) {
+        this.map.setGlyphs(this.style.glyphs)
+      }
+
+      Object.entries(this.style.sources || {}).map(([key, value]) => {
+        if (this.map.style && this.map.getSource(`${this.name}/${key}`)) return
+        this.map.addSource(`${this.name}/${key}`, value)
+      })
+
+      this.style.layers?.map(layer => {
+        if (this.map.getLayer(`${this.name}/${layer.id}`)) return
+
+        this.map.addLayer({
+          ...layer,
+          id: `${this.name}/${layer.id}`,
+          source: `${this.name}/${layer.source}`
+        }, nextLayer)
+      })
     })
   },
   unmounted() {
     const layerRE = new RegExp(`^${this.name}/`)
+
+    if (!this.map.isStyleLoaded()) {
+      return
+    }
+
     this.map.getLayersOrder()
       .filter(name => layerRE.test(name))
       .filter(name => this.map.getLayer(name))

--- a/src/components/Map/LayerSelector.vue
+++ b/src/components/Map/LayerSelector.vue
@@ -1,30 +1,3 @@
-<script setup>
-import { ref } from "vue"
-
-const showMenu = ref(false)
-
-defineProps({
-  fond: {
-    type: String,
-    required: true,
-  },
-  classification: {
-    type: Boolean,
-    required: true,
-  },
-  cadastre: {
-    type: Boolean,
-    required: true,
-  },
-  ilots: {
-    type: Boolean,
-    required: true,
-  },
-})
-
-defineEmits(['update:fond', 'update:classification', 'update:cadastre', 'update:ilots'])
-</script>
-
 <template>
 <Teleport to=".maplibregl-ctrl-bottom-left">
   <div class="container maplibregl-ctrl">
@@ -34,11 +7,12 @@ defineEmits(['update:fond', 'update:classification', 'update:cadastre', 'update:
       @click="showMenu = !showMenu"
     >
       <span class="fr-icon--sm fr-mb-1v">
-        Cartes
+        Calques
       </span>
     </button>
-    <div class="menu" v-if="showMenu">
-      <h5 class="fr-mb-2w">Cartes</h5>
+    <div class="menu" v-if="showMenu" ref="layersMenuRef">
+      <h5 class="fr-mb-2w">Calques</h5>``
+
       <button
         class="close-button fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-right fr-icon-close-line"
         @click="showMenu = false"
@@ -60,22 +34,47 @@ defineEmits(['update:fond', 'update:classification', 'update:cadastre', 'update:
       <button aria-label="Calque classification" class="menu-entry" :class="{ 'active': classification }" @click="$emit('update:classification', !classification)">
         <img src="@/assets/map/classification.jpg" alt="" />
         <span>
-          Classification
+          RPG Bio {{ currentCampagne }}
           <small class="fr-hint-text">Voir la <a href="https://docs-cartobio.agencebio.org/agriculteurs.trices/annexes/legendes-de-la-carte" @click.stop target="_blank">méthode de classification</a></small>
         </span>
       </button>
       <button aria-label="Calque numéros de cadastre" class="menu-entry" :class="{ 'active': cadastre }" @click="$emit('update:cadastre', !cadastre)">
         <img src="@/assets/map/cadastre.jpg" alt="" />
-        <span>Numéros de cadastre</span>
-      </button>
-      <button aria-label="Calque " class="menu-entry" :class="{ 'active': ilots }" @click="$emit('update:ilots', !ilots)">
-        <img src="../../assets/map/ilots.png" alt="" />
-        <span>Numéros d'îlots (PAC)</span>
+        <span>Cadastre</span>
       </button>
     </div>
   </div>
 </Teleport>
 </template>
+
+<script setup>
+import { ref } from "vue"
+import { onClickOutside } from "@vueuse/core"
+import { useTélépac } from "@/referentiels/pac.js";
+
+const showMenu = ref(false)
+const layersMenuRef = ref(null)
+const { campagne: currentCampagne } = useTélépac()
+
+defineProps({
+  fond: {
+    type: String,
+    required: true,
+  },
+  classification: {
+    type: Boolean,
+    required: true,
+  },
+  cadastre: {
+    type: Boolean,
+    required: true,
+  }
+})
+
+defineEmits(['update:fond', 'update:classification', 'update:cadastre'])
+
+onClickOutside(layersMenuRef, () => showMenu.value = false)
+</script>
 
 <style scoped>
 

--- a/src/components/Map/MapContainer.test.js
+++ b/src/components/Map/MapContainer.test.js
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "vitest"
-import { mount } from "@vue/test-utils"
+import { flushPromises, mount } from "@vue/test-utils"
 import { NavigationControl, ScaleControl } from 'maplibre-gl'
 
 import MapContainer from "./MapContainer.vue"
+import LayerSelector from "./LayerSelector.vue"
 
 describe("MapContainer", () => {
   test('we display navigation with no interactive elements', async () => {
@@ -38,5 +39,28 @@ describe("MapContainer", () => {
     const attributionSpy = wrapper.vm.map.addControl.mock.calls.at(2)
     expect(attributionSpy).toHaveProperty('0.onAdd')
     expect(attributionSpy).toHaveProperty('1', 'bottom-right')
+  })
+})
+
+describe('LayerSelector', () => {
+  test('show menu and change layers, and click outside to close it', async () => {
+    const wrapper = mount(LayerSelector, {
+      props: {
+        'fond': 'plan',
+        'classification': false,
+        'cadastre': false
+      },
+      global: {
+        stubs: {
+          teleport: true
+        }
+      }
+    })
+
+
+    const menu = wrapper.getComponent(LayerSelector)
+    expect(menu.find('.menu').exists()).toEqual(false)
+    await menu.find('.menu-toggle--plan').trigger('click')
+    await flushPromises()
   })
 })

--- a/src/components/Map/MapContainer.vue
+++ b/src/components/Map/MapContainer.vue
@@ -8,6 +8,8 @@
 import { onMounted, onUpdated, provide, ref, shallowRef, watch } from 'vue'
 import { Map as MapLibre, NavigationControl, ScaleControl } from 'maplibre-gl'
 
+import style from '@/map-styles/base.json'
+
 const map = shallowRef(null)
 const mapContainer = ref(null)
 
@@ -51,6 +53,7 @@ onMounted(() => {
     bounds: props.bounds,
     padding: 50,
     ...props.options,
+    style,
     locale: {
       'AttributionControl.ToggleAttribution': 'Déplier/replier les informations',
       'NavigationControl.ResetBearing': 'Restaurer l’orientation au nord',

--- a/src/components/Map/Preview.vue
+++ b/src/components/Map/Preview.vue
@@ -1,6 +1,6 @@
 <template>
   <MapContainer :controls="controls" class="map map--preview" :options="{ interactive: false, hash: false, trackResize: false }" minInitialZoom="22" :bounds="mapBounds">
-    <GeojsonLayer :style="baseStyle" name="base" />
+    <GeojsonLayer :style="planStyle" name="plan" />
     <FeaturesLayer :data="collection" />
   </MapContainer>
 </template>
@@ -11,7 +11,7 @@ import { bounds } from '@/components/Features/index.js'
 
 import MapContainer from './MapContainer.vue'
 import GeojsonLayer from './GeojsonLayer.vue'
-import baseStyle from '@/map-styles/base.json'
+import planStyle from '@/map-styles/plan.json'
 import FeaturesLayer from "@/components/Map/FeaturesLayer.vue"
 
 const props = defineProps({

--- a/src/map-styles/base.json
+++ b/src/map-styles/base.json
@@ -1,44 +1,11 @@
 {
   "version": 8,
-  "name": "Bright",
-  "metadata": {
-    "mapbox:autocomposite": false,
-    "mapbox:groups": {
-      "1444849242106.713": {
-        "collapsed": false,
-        "name": "Places"
-      },
-      "1444849334699.1902": {
-        "collapsed": true,
-        "name": "Bridges"
-      },
-      "1444849345966.4436": {
-        "collapsed": false,
-        "name": "Roads"
-      },
-      "1444849354174.1904": {
-        "collapsed": true,
-        "name": "Tunnels"
-      },
-      "1444849364238.8171": {
-        "collapsed": false,
-        "name": "Buildings"
-      },
-      "1444849382550.77": {
-        "collapsed": false,
-        "name": "Water"
-      },
-      "1444849388993.3071": {
-        "collapsed": false,
-        "name": "Land"
-      }
-    },
-    "mapbox:type": "template",
-    "openmaptiles:mapbox:owner": "openmaptiles",
-    "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t",
-    "openmaptiles:version": "3.x"
-  },
-  "center": [0, 0],
+  "id": "base",
+  "name": "Base",
+  "center": [
+    0,
+    0
+  ],
   "zoom": 1,
   "bearing": 0,
   "pitch": 0,
@@ -50,3141 +17,1330 @@
   },
   "sprite": "https://openmaptiles.github.io/osm-bright-gl-style/sprite",
   "glyphs": "https://openmaptiles.geo.data.gouv.fr/fonts/{fontstack}/{range}.pbf",
-  "layers": [{
-    "id": "background",
-    "type": "background",
-    "paint": {
-      "background-color": "#f8f4f0"
-    }
-    }, {
-      "id": "landcover-glacier",
-      "type": "fill",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "#f8f4f0"
+      }
+    },
+    {
+      "id": "waterway-name",
+      "type": "symbol",
       "source": "openmaptiles",
-      "source-layer": "landcover",
-      "filter": ["==", "subclass", "glacier"],
+      "source-layer": "waterway",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ],
       "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": 14
+      },
+      "paint": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "water-name-lakeline",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "filter": [
+        "==",
+        "$type",
+        "LineString"
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": 14
+      },
+      "paint": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "water-name-ocean",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "==",
+          "class",
+          "ocean"
+        ]
+      ],
+      "layout": {
+        "symbol-placement": "point",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}",
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": 14
+      },
+      "paint": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "water-name-other",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "!in",
+          "class",
+          "ocean"
+        ]
+      ],
+      "layout": {
+        "symbol-placement": "point",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": {
+          "stops": [
+            [
+              0,
+              10
+            ],
+            [
+              6,
+              14
+            ]
+          ]
+        },
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "#fff",
-        "fill-opacity": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi-level-3",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          ">=",
+          "rank",
+          25
+        ],
+        [
+          "any",
+          [
+            "!has",
+            "level"
+          ],
+          [
+            "==",
+            "level",
+            0
+          ]
+        ]
+      ],
+      "layout": {
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.6
+        ],
+        "text-padding": 2,
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi-level-2",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "<=",
+          "rank",
+          24
+        ],
+        [
+          ">=",
+          "rank",
+          15
+        ],
+        [
+          "any",
+          [
+            "!has",
+            "level"
+          ],
+          [
+            "==",
+            "level",
+            0
+          ]
+        ]
+      ],
+      "layout": {
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.6
+        ],
+        "text-padding": 2,
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi-level-1",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "<=",
+          "rank",
+          14
+        ],
+        [
+          "has",
+          "name"
+        ],
+        [
+          "any",
+          [
+            "!has",
+            "level"
+          ],
+          [
+            "==",
+            "level",
+            0
+          ]
+        ]
+      ],
+      "layout": {
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.6
+        ],
+        "text-padding": 2,
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi-railway",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "has",
+          "name"
+        ],
+        [
+          "==",
+          "class",
+          "railway"
+        ],
+        [
+          "==",
+          "subclass",
+          "station"
+        ]
+      ],
+      "layout": {
+        "icon-allow-overlap": false,
+        "icon-ignore-placement": false,
+        "icon-image": "{class}_11",
+        "icon-optional": false,
+        "text-allow-overlap": false,
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-ignore-placement": false,
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.6
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": 12
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "road_oneway",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        [
+          "==",
+          "oneway",
+          1
+        ],
+        [
+          "in",
+          "class",
+          "motorway",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary",
+          "minor",
+          "service"
+        ]
+      ],
+      "layout": {
+        "icon-image": "oneway",
+        "icon-padding": 2,
+        "icon-rotate": 90,
+        "icon-rotation-alignment": "map",
+        "icon-size": {
+          "stops": [
+            [
+              15,
+              0.5
+            ],
+            [
+              19,
+              1
+            ]
+          ]
+        },
+        "symbol-placement": "line",
+        "symbol-spacing": 75
+      },
+      "paint": {
+        "icon-opacity": 0.5
+      }
+    },
+    {
+      "id": "road_oneway_opposite",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        [
+          "==",
+          "oneway",
+          -1
+        ],
+        [
+          "in",
+          "class",
+          "motorway",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary",
+          "minor",
+          "service"
+        ]
+      ],
+      "layout": {
+        "icon-image": "oneway",
+        "icon-padding": 2,
+        "icon-rotate": -90,
+        "icon-rotation-alignment": "map",
+        "icon-size": {
+          "stops": [
+            [
+              15,
+              0.5
+            ],
+            [
+              19,
+              1
+            ]
+          ]
+        },
+        "symbol-placement": "line",
+        "symbol-spacing": 75
+      },
+      "paint": {
+        "icon-opacity": 0.5
+      }
+    },
+    {
+      "id": "highway-name-path",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 15.5,
+      "filter": [
+        "==",
+        "class",
+        "path"
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "map",
+        "text-size": {
           "base": 1,
           "stops": [
-            [0, 0.9],
-            [10, 0.3]
+            [
+              13,
+              12
+            ],
+            [
+              14,
+              13
+            ]
           ]
         }
+      },
+      "paint": {
+        "text-color": "hsl(30, 23%, 62%)",
+        "text-halo-color": "#f8f4f0",
+        "text-halo-width": 0.5
       }
-      }, {
-        "id": "landuse-residential",
-        "type": "fill",
-        "metadata": {
-          "mapbox:group": "1444849388993.3071"
-        },
-        "source": "openmaptiles",
-        "source-layer": "landuse",
-        "filter": ["all", ["in", "class", "residential", "suburb", "neighbourhood"]],
-        "layout": {
-          "visibility": "visible"
-        },
-        "paint": {
-          "fill-color": {
-            "base": 1,
-            "stops": [
-              [12, "hsla(30, 19%, 90%, 0.4)"],
-              [16, "hsla(30, 19%, 90%, 0.2)"]
+    },
+    {
+      "id": "highway-name-minor",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "minor",
+          "service",
+          "track"
+        ]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "map",
+        "text-size": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              12
+            ],
+            [
+              14,
+              13
             ]
-          }
+          ]
         }
-        }, {
-          "id": "landuse-commercial",
-          "type": "fill",
-          "metadata": {
-            "mapbox:group": "1444849388993.3071"
-          },
-          "source": "openmaptiles",
-          "source-layer": "landuse",
-          "filter": ["all", ["==", "$type", "Polygon"],
-          ["==", "class", "commercial"]
+      },
+      "paint": {
+        "text-color": "#765",
+        "text-halo-blur": 0.5,
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "highway-name-major",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 12.2,
+      "filter": [
+        "in",
+        "class",
+        "primary",
+        "secondary",
+        "tertiary",
+        "trunk"
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
         ],
-        "layout": {
-          "visibility": "visible"
-        },
-        "paint": {
-          "fill-color": "hsla(0, 60%, 87%, 0.23)"
+        "text-rotation-alignment": "map",
+        "text-size": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              12
+            ],
+            [
+              14,
+              13
+            ]
+          ]
         }
-        }, {
-          "id": "landuse-industrial",
-          "type": "fill",
-          "source": "openmaptiles",
-          "source-layer": "landuse",
-          "filter": ["all", ["==", "$type", "Polygon"],
-          ["in", "class", "industrial", "garages", "dam"]
+      },
+      "paint": {
+        "text-color": "#765",
+        "text-halo-blur": 0.5,
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "highway-shield",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
         ],
-        "layout": {
-          "visibility": "visible"
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!in",
+          "network",
+          "us-interstate",
+          "us-highway",
+          "us-state"
+        ]
+      ],
+      "layout": {
+        "icon-image": "road_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              10,
+              "point"
+            ],
+            [
+              11,
+              "line"
+            ]
+          ]
         },
-        "paint": {
-          "fill-color": "hsla(49, 100%, 88%, 0.34)"
-        }
-        }, {
-          "id": "landuse-cemetery",
-          "type": "fill",
-          "metadata": {
-            "mapbox:group": "1444849388993.3071"
-          },
-          "source": "openmaptiles",
-          "source-layer": "landuse",
-          "filter": ["==", "class", "cemetery"],
-          "paint": {
-            "fill-color": "#e0e4dd"
-          }
-          }, {
-            "id": "landuse-hospital",
-            "type": "fill",
-            "metadata": {
-              "mapbox:group": "1444849388993.3071"
-            },
-            "source": "openmaptiles",
-            "source-layer": "landuse",
-            "filter": ["==", "class", "hospital"],
-            "paint": {
-              "fill-color": "#fde"
-            }
-            }, {
-              "id": "landuse-school",
-              "type": "fill",
-              "metadata": {
-                "mapbox:group": "1444849388993.3071"
-              },
-              "source": "openmaptiles",
-              "source-layer": "landuse",
-              "filter": ["==", "class", "school"],
-              "paint": {
-                "fill-color": "#f0e8f8"
-              }
-              }, {
-                "id": "landuse-railway",
-                "type": "fill",
-                "metadata": {
-                  "mapbox:group": "1444849388993.3071"
-                },
-                "source": "openmaptiles",
-                "source-layer": "landuse",
-                "filter": ["==", "class", "railway"],
-                "layout": {
-                  "visibility": "visible"
-                },
-                "paint": {
-                  "fill-color": "hsla(30, 19%, 90%, 0.4)"
-                }
-                }, {
-                  "id": "landcover-wood",
-                  "type": "fill",
-                  "metadata": {
-                    "mapbox:group": "1444849388993.3071"
-                  },
-                  "source": "openmaptiles",
-                  "source-layer": "landcover",
-                  "filter": ["==", "class", "wood"],
-                  "paint": {
-                    "fill-antialias": {
-                      "base": 1,
-                      "stops": [
-                        [0, false],
-                        [9, true]
-                      ]
-                    },
-                    "fill-color": "#6a4",
-                    "fill-opacity": 0.1,
-                    "fill-outline-color": "hsla(0, 0%, 0%, 0.03)"
-                  }
-                  }, {
-                    "id": "landcover-grass",
-                    "type": "fill",
-                    "metadata": {
-                      "mapbox:group": "1444849388993.3071"
-                    },
-                    "source": "openmaptiles",
-                    "source-layer": "landcover",
-                    "filter": ["==", "class", "grass"],
-                    "paint": {
-                      "fill-color": "#d8e8c8",
-                      "fill-opacity": 1
-                    }
-                    }, {
-                      "id": "landcover-grass-park",
-                      "type": "fill",
-                      "metadata": {
-                        "mapbox:group": "1444849388993.3071"
-                      },
-                      "source": "openmaptiles",
-                      "source-layer": "park",
-                      "filter": ["==", "class", "public_park"],
-                      "paint": {
-                        "fill-color": "#d8e8c8",
-                        "fill-opacity": 0.8
-                      }
-                      }, {
-                        "id": "waterway_tunnel",
-                        "type": "line",
-                        "source": "openmaptiles",
-                        "source-layer": "waterway",
-                        "minzoom": 14,
-                        "filter": ["all", ["in", "class", "river", "stream", "canal"],
-                        ["==", "brunnel", "tunnel"]
-                      ],
-                      "layout": {
-                        "line-cap": "round",
-                        "visibility": "visible"
-                      },
-                      "paint": {
-                        "line-color": "#a0c8f0",
-                        "line-dasharray": [2, 4],
-                        "line-width": {
-                          "base": 1.3,
-                          "stops": [
-                            [13, 0.5],
-                            [20, 6]
-                          ]
-                        }
-                      }
-                      }, {
-                        "id": "waterway-other",
-                        "type": "line",
-                        "metadata": {
-                          "mapbox:group": "1444849382550.77"
-                        },
-                        "source": "openmaptiles",
-                        "source-layer": "waterway",
-                        "filter": ["all", ["!in", "class", "canal", "river", "stream"],
-                        ["==", "intermittent", 0]
-                      ],
-                      "layout": {
-                        "line-cap": "round",
-                        "visibility": "visible"
-                      },
-                      "paint": {
-                        "line-color": "#a0c8f0",
-                        "line-width": {
-                          "base": 1.3,
-                          "stops": [
-                            [13, 0.5],
-                            [20, 2]
-                          ]
-                        }
-                      }
-                      }, {
-                        "id": "waterway-other-intermittent",
-                        "type": "line",
-                        "metadata": {
-                          "mapbox:group": "1444849382550.77"
-                        },
-                        "source": "openmaptiles",
-                        "source-layer": "waterway",
-                        "filter": ["all", ["!in", "class", "canal", "river", "stream"],
-                        ["==", "intermittent", 1]
-                      ],
-                      "layout": {
-                        "line-cap": "round",
-                        "visibility": "visible"
-                      },
-                      "paint": {
-                        "line-color": "#a0c8f0",
-                        "line-dasharray": [4, 3],
-                        "line-width": {
-                          "base": 1.3,
-                          "stops": [
-                            [13, 0.5],
-                            [20, 2]
-                          ]
-                        }
-                      }
-                      }, {
-                        "id": "waterway-stream-canal",
-                        "type": "line",
-                        "metadata": {
-                          "mapbox:group": "1444849382550.77"
-                        },
-                        "source": "openmaptiles",
-                        "source-layer": "waterway",
-                        "filter": ["all", ["in", "class", "canal", "stream"],
-                        ["!=", "brunnel", "tunnel"],
-                        ["==", "intermittent", 0]
-                      ],
-                      "layout": {
-                        "line-cap": "round",
-                        "visibility": "visible"
-                      },
-                      "paint": {
-                        "line-color": "#a0c8f0",
-                        "line-width": {
-                          "base": 1.3,
-                          "stops": [
-                            [13, 0.5],
-                            [20, 6]
-                          ]
-                        }
-                      }
-                      }, {
-                        "id": "waterway-stream-canal-intermittent",
-                        "type": "line",
-                        "metadata": {
-                          "mapbox:group": "1444849382550.77"
-                        },
-                        "source": "openmaptiles",
-                        "source-layer": "waterway",
-                        "filter": ["all", ["in", "class", "canal", "stream"],
-                        ["!=", "brunnel", "tunnel"],
-                        ["==", "intermittent", 1]
-                      ],
-                      "layout": {
-                        "line-cap": "round",
-                        "visibility": "visible"
-                      },
-                      "paint": {
-                        "line-color": "#a0c8f0",
-                        "line-dasharray": [4, 3],
-                        "line-width": {
-                          "base": 1.3,
-                          "stops": [
-                            [13, 0.5],
-                            [20, 6]
-                          ]
-                        }
-                      }
-                      }, {
-                        "id": "waterway-river",
-                        "type": "line",
-                        "metadata": {
-                          "mapbox:group": "1444849382550.77"
-                        },
-                        "source": "openmaptiles",
-                        "source-layer": "waterway",
-                        "filter": ["all", ["==", "class", "river"],
-                        ["!=", "brunnel", "tunnel"],
-                        ["==", "intermittent", 0]
-                      ],
-                      "layout": {
-                        "line-cap": "round",
-                        "visibility": "visible"
-                      },
-                      "paint": {
-                        "line-color": "#a0c8f0",
-                        "line-width": {
-                          "base": 1.2,
-                          "stops": [
-                            [10, 0.8],
-                            [20, 6]
-                          ]
-                        }
-                      }
-                      }, {
-                        "id": "waterway-river-intermittent",
-                        "type": "line",
-                        "metadata": {
-                          "mapbox:group": "1444849382550.77"
-                        },
-                        "source": "openmaptiles",
-                        "source-layer": "waterway",
-                        "filter": ["all", ["==", "class", "river"],
-                        ["!=", "brunnel", "tunnel"],
-                        ["==", "intermittent", 1]
-                      ],
-                      "layout": {
-                        "line-cap": "round",
-                        "visibility": "visible"
-                      },
-                      "paint": {
-                        "line-color": "#a0c8f0",
-                        "line-dasharray": [3, 2.5],
-                        "line-width": {
-                          "base": 1.2,
-                          "stops": [
-                            [10, 0.8],
-                            [20, 6]
-                          ]
-                        }
-                      }
-                      }, {
-                        "id": "water-offset",
-                        "type": "fill",
-                        "metadata": {
-                          "mapbox:group": "1444849382550.77"
-                        },
-                        "source": "openmaptiles",
-                        "source-layer": "water",
-                        "maxzoom": 8,
-                        "filter": ["==", "$type", "Polygon"],
-                        "layout": {
-                          "visibility": "visible"
-                        },
-                        "paint": {
-                          "fill-color": "#a0c8f0",
-                          "fill-opacity": 1,
-                          "fill-translate": {
-                            "base": 1,
-                            "stops": [
-                              [6, [2, 0]],
-                              [8, [0, 0]]
-                            ]
-                          }
-                        }
-                        }, {
-                          "id": "water",
-                          "type": "fill",
-                          "metadata": {
-                            "mapbox:group": "1444849382550.77"
-                          },
-                          "source": "openmaptiles",
-                          "source-layer": "water",
-                          "filter": ["all", ["!=", "intermittent", 1],
-                          ["!=", "brunnel", "tunnel"]
-                        ],
-                        "layout": {
-                          "visibility": "visible"
-                        },
-                        "paint": {
-                          "fill-color": "hsl(210, 67%, 85%)"
-                        }
-                        }, {
-                          "id": "water-intermittent",
-                          "type": "fill",
-                          "metadata": {
-                            "mapbox:group": "1444849382550.77"
-                          },
-                          "source": "openmaptiles",
-                          "source-layer": "water",
-                          "filter": ["all", ["==", "intermittent", 1]],
-                          "layout": {
-                            "visibility": "visible"
-                          },
-                          "paint": {
-                            "fill-color": "hsl(210, 67%, 85%)",
-                            "fill-opacity": 0.7
-                          }
-                          }, {
-                            "id": "water-pattern",
-                            "type": "fill",
-                            "metadata": {
-                              "mapbox:group": "1444849382550.77"
-                            },
-                            "source": "openmaptiles",
-                            "source-layer": "water",
-                            "filter": ["all"],
-                            "layout": {
-                              "visibility": "visible"
-                            },
-                            "paint": {
-                              "fill-pattern": "wave",
-                              "fill-translate": [0, 2.5]
-                            }
-                            }, {
-                              "id": "landcover-ice-shelf",
-                              "type": "fill",
-                              "metadata": {
-                                "mapbox:group": "1444849382550.77"
-                              },
-                              "source": "openmaptiles",
-                              "source-layer": "landcover",
-                              "filter": ["==", "subclass", "ice_shelf"],
-                              "layout": {
-                                "visibility": "visible"
-                              },
-                              "paint": {
-                                "fill-color": "#fff",
-                                "fill-opacity": {
-                                  "base": 1,
-                                  "stops": [
-                                    [0, 0.9],
-                                    [10, 0.3]
-                                  ]
-                                }
-                              }
-                              }, {
-                                "id": "landcover-sand",
-                                "type": "fill",
-                                "metadata": {
-                                  "mapbox:group": "1444849382550.77"
-                                },
-                                "source": "openmaptiles",
-                                "source-layer": "landcover",
-                                "filter": ["all", ["==", "class", "sand"]],
-                                "layout": {
-                                  "visibility": "visible"
-                                },
-                                "paint": {
-                                  "fill-color": "rgba(245, 238, 188, 1)",
-                                  "fill-opacity": 1
-                                }
-                                }, {
-                                  "id": "building",
-                                  "type": "fill",
-                                  "metadata": {
-                                    "mapbox:group": "1444849364238.8171"
-                                  },
-                                  "source": "openmaptiles",
-                                  "source-layer": "building",
-                                  "paint": {
-                                    "fill-antialias": true,
-                                    "fill-color": {
-                                      "base": 1,
-                                      "stops": [
-                                        [15.5, "#f2eae2"],
-                                        [16, "#dfdbd7"]
-                                      ]
-                                    }
-                                  }
-                                  }, {
-                                    "id": "building-top",
-                                    "type": "fill",
-                                    "metadata": {
-                                      "mapbox:group": "1444849364238.8171"
-                                    },
-                                    "source": "openmaptiles",
-                                    "source-layer": "building",
-                                    "layout": {
-                                      "visibility": "visible"
-                                    },
-                                    "paint": {
-                                      "fill-color": "#f2eae2",
-                                      "fill-opacity": {
-                                        "base": 1,
-                                        "stops": [
-                                          [13, 0],
-                                          [16, 1]
-                                        ]
-                                      },
-                                      "fill-outline-color": "#dfdbd7",
-                                      "fill-translate": {
-                                        "base": 1,
-                                        "stops": [
-                                          [14, [0, 0]],
-                                          [16, [-2, -2]]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-service-track-casing",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["in", "class", "service", "track"]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round"
-                                    },
-                                    "paint": {
-                                      "line-color": "#cfcdca",
-                                      "line-dasharray": [0.5, 0.25],
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [15, 1],
-                                          [16, 4],
-                                          [20, 11]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-motorway-link-casing",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["==", "class", "motorway"],
-                                      ["==", "ramp", 1]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round",
-                                      "visibility": "visible"
-                                    },
-                                    "paint": {
-                                      "line-color": "rgba(200, 147, 102, 1)",
-                                      "line-dasharray": [0.5, 0.25],
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [12, 1],
-                                          [13, 3],
-                                          [14, 4],
-                                          [20, 15]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-minor-casing",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["==", "class", "minor"]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round"
-                                    },
-                                    "paint": {
-                                      "line-color": "#cfcdca",
-                                      "line-opacity": {
-                                        "stops": [
-                                          [12, 0],
-                                          [12.5, 1]
-                                        ]
-                                      },
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [12, 0.5],
-                                          [13, 1],
-                                          [14, 4],
-                                          [20, 15]
-                                        ]
-                                      },
-                                      "line-dasharray": [0.5, 0.25]
-                                    }
-                                    }, {
-                                      "id": "tunnel-link-casing",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["in", "class", "trunk", "primary", "secondary", "tertiary"],
-                                      ["==", "ramp", 1]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round"
-                                    },
-                                    "paint": {
-                                      "line-color": "#e9ac77",
-                                      "line-opacity": 1,
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [12, 1],
-                                          [13, 3],
-                                          [14, 4],
-                                          [20, 15]
-                                        ]
-                                      },
-                                      "line-dasharray": [0.5, 0.25]
-                                    }
-                                    }, {
-                                      "id": "tunnel-secondary-tertiary-casing",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["in", "class", "secondary", "tertiary"],
-                                      ["!=", "ramp", 1]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round"
-                                    },
-                                    "paint": {
-                                      "line-color": "#e9ac77",
-                                      "line-opacity": 1,
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [8, 1.5],
-                                          [20, 17]
-                                        ]
-                                      },
-                                      "line-dasharray": [0.5, 0.25]
-                                    }
-                                    }, {
-                                      "id": "tunnel-trunk-primary-casing",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["in", "class", "primary", "trunk"],
-                                      ["!=", "ramp", 1]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round"
-                                    },
-                                    "paint": {
-                                      "line-color": "#e9ac77",
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [5, 0.4],
-                                          [6, 0.6],
-                                          [7, 1.5],
-                                          [20, 22]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-motorway-casing",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["==", "class", "motorway"],
-                                      ["!=", "ramp", 1]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round",
-                                      "visibility": "visible"
-                                    },
-                                    "paint": {
-                                      "line-color": "#e9ac77",
-                                      "line-dasharray": [0.5, 0.25],
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [5, 0.4],
-                                          [6, 0.6],
-                                          [7, 1.5],
-                                          [20, 22]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-path",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "$type", "LineString"],
-                                      ["==", "brunnel", "tunnel"],
-                                      ["==", "class", "path"]
-                                    ],
-                                    "paint": {
-                                      "line-color": "#cba",
-                                      "line-dasharray": [1.5, 0.75],
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [15, 1.2],
-                                          [20, 4]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-motorway-link",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["==", "class", "motorway"],
-                                      ["==", "ramp", 1]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round",
-                                      "visibility": "visible"
-                                    },
-                                    "paint": {
-                                      "line-color": "rgba(244, 209, 158, 1)",
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [12.5, 0],
-                                          [13, 1.5],
-                                          [14, 2.5],
-                                          [20, 11.5]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-service-track",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["in", "class", "service", "track"]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round"
-                                    },
-                                    "paint": {
-                                      "line-color": "#fff",
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [15.5, 0],
-                                          [16, 2],
-                                          [20, 7.5]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-link",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["in", "class", "trunk", "primary", "secondary", "tertiary"],
-                                      ["==", "ramp", 1]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round"
-                                    },
-                                    "paint": {
-                                      "line-color": "#fff4c6",
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [12.5, 0],
-                                          [13, 1.5],
-                                          [14, 2.5],
-                                          [20, 11.5]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-minor",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["==", "class", "minor_road"]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round"
-                                    },
-                                    "paint": {
-                                      "line-color": "#fff",
-                                      "line-opacity": 1,
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [13.5, 0],
-                                          [14, 2.5],
-                                          [20, 11.5]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-secondary-tertiary",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["in", "class", "secondary", "tertiary"],
-                                      ["!=", "ramp", 1]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round"
-                                    },
-                                    "paint": {
-                                      "line-color": "#fff4c6",
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [6.5, 0],
-                                          [7, 0.5],
-                                          [20, 10]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-trunk-primary",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["in", "class", "primary", "trunk"],
-                                      ["!=", "ramp", 1]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round"
-                                    },
-                                    "paint": {
-                                      "line-color": "#fff4c6",
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [6.5, 0],
-                                          [7, 0.5],
-                                          [20, 18]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-motorway",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["==", "class", "motorway"],
-                                      ["!=", "ramp", 1]
-                                    ],
-                                    "layout": {
-                                      "line-join": "round",
-                                      "visibility": "visible"
-                                    },
-                                    "paint": {
-                                      "line-color": "#ffdaa6",
-                                      "line-width": {
-                                        "base": 1.2,
-                                        "stops": [
-                                          [6.5, 0],
-                                          [7, 0.5],
-                                          [20, 18]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "tunnel-railway",
-                                      "type": "line",
-                                      "metadata": {
-                                        "mapbox:group": "1444849354174.1904"
-                                      },
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["==", "brunnel", "tunnel"],
-                                      ["==", "class", "rail"]
-                                    ],
-                                    "paint": {
-                                      "line-color": "#bbb",
-                                      "line-dasharray": [2, 2],
-                                      "line-width": {
-                                        "base": 1.4,
-                                        "stops": [
-                                          [14, 0.4],
-                                          [15, 0.75],
-                                          [20, 2]
-                                        ]
-                                      }
-                                    }
-                                    }, {
-                                      "id": "ferry",
-                                      "type": "line",
-                                      "source": "openmaptiles",
-                                      "source-layer": "transportation",
-                                      "filter": ["all", ["in", "class", "ferry"]],
-                                      "layout": {
-                                        "line-join": "round",
-                                        "visibility": "visible"
-                                      },
-                                      "paint": {
-                                        "line-color": "rgba(108, 159, 182, 1)",
-                                        "line-dasharray": [2, 2],
-                                        "line-width": 1.1
-                                      }
-                                      }, {
-                                        "id": "aeroway-taxiway-casing",
-                                        "type": "line",
-                                        "metadata": {
-                                          "mapbox:group": "1444849345966.4436"
-                                        },
-                                        "source": "openmaptiles",
-                                        "source-layer": "aeroway",
-                                        "minzoom": 12,
-                                        "filter": ["all", ["in", "class", "taxiway"]],
-                                        "layout": {
-                                          "line-cap": "round",
-                                          "line-join": "round",
-                                          "visibility": "visible"
-                                        },
-                                        "paint": {
-                                          "line-color": "rgba(153, 153, 153, 1)",
-                                          "line-opacity": 1,
-                                          "line-width": {
-                                            "base": 1.5,
-                                            "stops": [
-                                              [11, 2],
-                                              [17, 12]
-                                            ]
-                                          }
-                                        }
-                                        }, {
-                                          "id": "aeroway-runway-casing",
-                                          "type": "line",
-                                          "metadata": {
-                                            "mapbox:group": "1444849345966.4436"
-                                          },
-                                          "source": "openmaptiles",
-                                          "source-layer": "aeroway",
-                                          "minzoom": 12,
-                                          "filter": ["all", ["in", "class", "runway"]],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "rgba(153, 153, 153, 1)",
-                                            "line-opacity": 1,
-                                            "line-width": {
-                                              "base": 1.5,
-                                              "stops": [
-                                                [11, 5],
-                                                [17, 55]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "aeroway-area",
-                                            "type": "fill",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "aeroway",
-                                            "minzoom": 4,
-                                            "filter": ["all", ["==", "$type", "Polygon"],
-                                            ["in", "class", "runway", "taxiway"]
-                                          ],
-                                          "layout": {
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "fill-color": "rgba(255, 255, 255, 1)",
-                                            "fill-opacity": {
-                                              "base": 1,
-                                              "stops": [
-                                                [13, 0],
-                                                [14, 1]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "aeroway-taxiway",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "aeroway",
-                                            "minzoom": 4,
-                                            "filter": ["all", ["in", "class", "taxiway"],
-                                            ["==", "$type", "LineString"]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "rgba(255, 255, 255, 1)",
-                                            "line-opacity": {
-                                              "base": 1,
-                                              "stops": [
-                                                [11, 0],
-                                                [12, 1]
-                                              ]
-                                            },
-                                            "line-width": {
-                                              "base": 1.5,
-                                              "stops": [
-                                                [11, 1],
-                                                [17, 10]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "aeroway-runway",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "aeroway",
-                                            "minzoom": 4,
-                                            "filter": ["all", ["in", "class", "runway"],
-                                            ["==", "$type", "LineString"]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "rgba(255, 255, 255, 1)",
-                                            "line-opacity": {
-                                              "base": 1,
-                                              "stops": [
-                                                [11, 0],
-                                                [12, 1]
-                                              ]
-                                            },
-                                            "line-width": {
-                                              "base": 1.5,
-                                              "stops": [
-                                                [11, 4],
-                                                [17, 50]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "road_area_pier",
-                                            "type": "fill",
-                                            "metadata": {},
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "Polygon"],
-                                            ["==", "class", "pier"]
-                                          ],
-                                          "layout": {
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "fill-antialias": true,
-                                            "fill-color": "#f8f4f0"
-                                          }
-                                          }, {
-                                            "id": "road_pier",
-                                            "type": "line",
-                                            "metadata": {},
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["in", "class", "pier"]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#f8f4f0",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [15, 1],
-                                                [17, 4]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-area",
-                                            "type": "fill",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "Polygon"],
-                                            ["!in", "class", "pier"]
-                                          ],
-                                          "layout": {
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "fill-antialias": false,
-                                            "fill-color": "hsla(0, 0%, 89%, 0.56)",
-                                            "fill-opacity": 0.9,
-                                            "fill-outline-color": "#cfcdca"
-                                          }
-                                          }, {
-                                            "id": "highway-motorway-link-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "minzoom": 12,
-                                            "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["==", "class", "motorway"],
-                                            ["==", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#e9ac77",
-                                            "line-opacity": 1,
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [12, 1],
-                                                [13, 3],
-                                                [14, 4],
-                                                [20, 15]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-link-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "minzoom": 13,
-                                            "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["in", "class", "trunk", "primary", "secondary", "tertiary"],
-                                            ["==", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "#e9ac77",
-                                            "line-opacity": 1,
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [12, 1],
-                                                [13, 3],
-                                                [14, 4],
-                                                [20, 15]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-minor-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["!=", "brunnel", "tunnel"],
-                                            ["in", "class", "minor", "service", "track"]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#cfcdca",
-                                            "line-opacity": {
-                                              "stops": [
-                                                [12, 0],
-                                                [12.5, 1]
-                                              ]
-                                            },
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [12, 0.5],
-                                                [13, 1],
-                                                [14, 4],
-                                                [20, 15]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-secondary-tertiary-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["in", "class", "secondary", "tertiary"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "butt",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "#e9ac77",
-                                            "line-opacity": 1,
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [8, 1.5],
-                                                [20, 17]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-primary-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "minzoom": 5,
-                                            "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["in", "class", "primary"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "butt",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "#e9ac77",
-                                            "line-opacity": {
-                                              "stops": [
-                                                [7, 0],
-                                                [8, 1]
-                                              ]
-                                            },
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [7, 0],
-                                                [8, 0.6],
-                                                [9, 1.5],
-                                                [20, 22]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-trunk-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "minzoom": 5,
-                                            "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["in", "class", "trunk"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "butt",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "#e9ac77",
-                                            "line-opacity": {
-                                              "stops": [
-                                                [5, 0],
-                                                [6, 1]
-                                              ]
-                                            },
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [5, 0],
-                                                [6, 0.6],
-                                                [7, 1.5],
-                                                [20, 22]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-motorway-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "minzoom": 4,
-                                            "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["==", "class", "motorway"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "butt",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "#e9ac77",
-                                            "line-opacity": {
-                                              "stops": [
-                                                [4, 0],
-                                                [5, 1]
-                                              ]
-                                            },
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [4, 0],
-                                                [5, 0.4],
-                                                [6, 0.6],
-                                                [7, 1.5],
-                                                [20, 22]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-path",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["==", "class", "path"]
-                                          ],
-                                          "paint": {
-                                            "line-color": "#cba",
-                                            "line-dasharray": [1.5, 0.75],
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [15, 1.2],
-                                                [20, 4]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-motorway-link",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "minzoom": 12,
-                                            "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["==", "class", "motorway"],
-                                            ["==", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fc8",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [12.5, 0],
-                                                [13, 1.5],
-                                                [14, 2.5],
-                                                [20, 11.5]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-link",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "minzoom": 13,
-                                            "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["in", "class", "trunk", "primary", "secondary", "tertiary"],
-                                            ["==", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fea",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [12.5, 0],
-                                                [13, 1.5],
-                                                [14, 2.5],
-                                                [20, 11.5]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-minor",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["!=", "brunnel", "tunnel"],
-                                            ["in", "class", "minor", "service", "track"]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fff",
-                                            "line-opacity": 1,
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [13.5, 0],
-                                                [14, 2.5],
-                                                [20, 11.5]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-secondary-tertiary",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["in", "class", "secondary", "tertiary"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fea",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [6.5, 0],
-                                                [8, 0.5],
-                                                [20, 13]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-primary",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["in", "class", "primary"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fea",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [8.5, 0],
-                                                [9, 0.5],
-                                                [20, 18]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-trunk",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["in", "class", "trunk"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fea",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [6.5, 0],
-                                                [7, 0.5],
-                                                [20, 18]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "highway-motorway",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "minzoom": 5,
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["==", "class", "motorway"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round",
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fc8",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [6.5, 0],
-                                                [7, 0.5],
-                                                [20, 18]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "railway-transit",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["==", "class", "transit"],
-                                            ["!in", "brunnel", "tunnel"]
-                                          ],
-                                          "layout": {
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "hsla(0, 0%, 73%, 0.77)",
-                                            "line-width": {
-                                              "base": 1.4,
-                                              "stops": [
-                                                [14, 0.4],
-                                                [20, 1]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "railway-transit-hatching",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["==", "class", "transit"],
-                                            ["!in", "brunnel", "tunnel"]
-                                          ],
-                                          "layout": {
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "hsla(0, 0%, 73%, 0.68)",
-                                            "line-dasharray": [0.2, 8],
-                                            "line-width": {
-                                              "base": 1.4,
-                                              "stops": [
-                                                [14.5, 0],
-                                                [15, 2],
-                                                [20, 6]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "railway-service",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["==", "class", "rail"],
-                                            ["has", "service"]
-                                          ],
-                                          "paint": {
-                                            "line-color": "hsla(0, 0%, 73%, 0.77)",
-                                            "line-width": {
-                                              "base": 1.4,
-                                              "stops": [
-                                                [14, 0.4],
-                                                [20, 1]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "railway-service-hatching",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["==", "class", "rail"],
-                                            ["has", "service"]
-                                          ],
-                                          "layout": {
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "line-color": "hsla(0, 0%, 73%, 0.68)",
-                                            "line-dasharray": [0.2, 8],
-                                            "line-width": {
-                                              "base": 1.4,
-                                              "stops": [
-                                                [14.5, 0],
-                                                [15, 2],
-                                                [20, 6]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "railway",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["!has", "service"],
-                                            ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["==", "class", "rail"]
-                                          ],
-                                          "paint": {
-                                            "line-color": "#bbb",
-                                            "line-width": {
-                                              "base": 1.4,
-                                              "stops": [
-                                                [14, 0.4],
-                                                [15, 0.75],
-                                                [20, 2]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "railway-hatching",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["!has", "service"],
-                                            ["!in", "brunnel", "bridge", "tunnel"],
-                                            ["==", "class", "rail"]
-                                          ],
-                                          "paint": {
-                                            "line-color": "#bbb",
-                                            "line-dasharray": [0.2, 8],
-                                            "line-width": {
-                                              "base": 1.4,
-                                              "stops": [
-                                                [14.5, 0],
-                                                [15, 3],
-                                                [20, 8]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-motorway-link-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["==", "class", "motorway"],
-                                            ["==", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#e9ac77",
-                                            "line-opacity": 1,
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [12, 1],
-                                                [13, 3],
-                                                [14, 4],
-                                                [20, 19]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-link-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["in", "class", "trunk", "primary", "secondary", "tertiary"],
-                                            ["==", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#e9ac77",
-                                            "line-opacity": 1,
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [12, 1],
-                                                [13, 3],
-                                                [14, 4],
-                                                [20, 19]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-secondary-tertiary-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["in", "class", "secondary", "tertiary"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#e9ac77",
-                                            "line-opacity": 1,
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [5, 0.4],
-                                                [7, 0.6],
-                                                [8, 1.5],
-                                                [20, 21]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-trunk-primary-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["in", "class", "primary", "trunk"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "hsl(28, 76%, 67%)",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [5, 0.4],
-                                                [6, 0.6],
-                                                [7, 1.5],
-                                                [20, 26]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-motorway-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["==", "class", "motorway"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#e9ac77",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [5, 0.4],
-                                                [6, 0.6],
-                                                [7, 1.5],
-                                                [20, 26]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-minor-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["==", "brunnel", "bridge"],
-                                            ["in", "class", "minor", "service", "track"]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "butt",
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#cfcdca",
-                                            "line-opacity": {
-                                              "stops": [
-                                                [12, 0],
-                                                [12.5, 1]
-                                              ]
-                                            },
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [12, 0.5],
-                                                [13, 1],
-                                                [14, 6],
-                                                [20, 24]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-path-casing",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["==", "brunnel", "bridge"],
-                                            ["==", "class", "path"]
-                                          ],
-                                          "paint": {
-                                            "line-color": "#f8f4f0",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [15, 1.2],
-                                                [20, 18]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-path",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["==", "brunnel", "bridge"],
-                                            ["==", "class", "path"]
-                                          ],
-                                          "paint": {
-                                            "line-color": "#cba",
-                                            "line-dasharray": [1.5, 0.75],
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [15, 1.2],
-                                                [20, 4]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-motorway-link",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["==", "class", "motorway"],
-                                            ["==", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fc8",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [12.5, 0],
-                                                [13, 1.5],
-                                                [14, 2.5],
-                                                [20, 11.5]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-link",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["in", "class", "trunk", "primary", "secondary", "tertiary"],
-                                            ["==", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fea",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [12.5, 0],
-                                                [13, 1.5],
-                                                [14, 2.5],
-                                                [20, 11.5]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-minor",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849345966.4436"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "$type", "LineString"],
-                                            ["==", "brunnel", "bridge"],
-                                            ["in", "class", "minor", "service", "track"]
-                                          ],
-                                          "layout": {
-                                            "line-cap": "round",
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fff",
-                                            "line-opacity": 1,
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [13.5, 0],
-                                                [14, 2.5],
-                                                [20, 11.5]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-secondary-tertiary",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["in", "class", "secondary", "tertiary"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fea",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [6.5, 0],
-                                                [8, 0.5],
-                                                [20, 13]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-trunk-primary",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["in", "class", "primary", "trunk"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fea",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [6.5, 0],
-                                                [7, 0.5],
-                                                [20, 18]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-motorway",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["==", "class", "motorway"],
-                                            ["!=", "ramp", 1]
-                                          ],
-                                          "layout": {
-                                            "line-join": "round"
-                                          },
-                                          "paint": {
-                                            "line-color": "#fc8",
-                                            "line-width": {
-                                              "base": 1.2,
-                                              "stops": [
-                                                [6.5, 0],
-                                                [7, 0.5],
-                                                [20, 18]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-railway",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["==", "class", "rail"]
-                                          ],
-                                          "paint": {
-                                            "line-color": "#bbb",
-                                            "line-width": {
-                                              "base": 1.4,
-                                              "stops": [
-                                                [14, 0.4],
-                                                [15, 0.75],
-                                                [20, 2]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "bridge-railway-hatching",
-                                            "type": "line",
-                                            "metadata": {
-                                              "mapbox:group": "1444849334699.1902"
-                                            },
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "filter": ["all", ["==", "brunnel", "bridge"],
-                                            ["==", "class", "rail"]
-                                          ],
-                                          "paint": {
-                                            "line-color": "#bbb",
-                                            "line-dasharray": [0.2, 8],
-                                            "line-width": {
-                                              "base": 1.4,
-                                              "stops": [
-                                                [14.5, 0],
-                                                [15, 3],
-                                                [20, 8]
-                                              ]
-                                            }
-                                          }
-                                          }, {
-                                            "id": "cablecar",
-                                            "type": "line",
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "minzoom": 13,
-                                            "filter": ["==", "subclass", "cable_car"],
-                                            "layout": {
-                                              "line-cap": "round",
-                                              "visibility": "visible"
-                                            },
-                                            "paint": {
-                                              "line-color": "hsl(0, 0%, 70%)",
-                                              "line-width": {
-                                                "base": 1,
-                                                "stops": [
-                                                  [11, 1],
-                                                  [19, 2.5]
-                                                ]
-                                              }
-                                            }
-                                            }, {
-                                              "id": "cablecar-dash",
-                                              "type": "line",
-                                              "source": "openmaptiles",
-                                              "source-layer": "transportation",
-                                              "minzoom": 13,
-                                              "filter": ["==", "subclass", "cable_car"],
-                                              "layout": {
-                                                "line-cap": "round",
-                                                "visibility": "visible"
-                                              },
-                                              "paint": {
-                                                "line-color": "hsl(0, 0%, 70%)",
-                                                "line-dasharray": [2, 3],
-                                                "line-width": {
-                                                  "base": 1,
-                                                  "stops": [
-                                                    [11, 3],
-                                                    [19, 5.5]
-                                                  ]
-                                                }
-                                              }
-                                              }, {
-                                                "id": "boundary-land-level-4",
-                                                "type": "line",
-                                                "source": "openmaptiles",
-                                                "source-layer": "boundary",
-                                                "minzoom": 2,
-                                                "filter": ["all", [">=", "admin_level", 3],
-                                                ["<=", "admin_level", 8],
-                                                ["!=", "maritime", 1]
-                                              ],
-                                              "layout": {
-                                                "line-join": "round",
-                                                "visibility": "visible"
-                                              },
-                                              "paint": {
-                                                "line-color": "#9e9cab",
-                                                "line-dasharray": [3, 1, 1, 1],
-                                                "line-width": {
-                                                  "base": 1.4,
-                                                  "stops": [
-                                                    [4, 0.4],
-                                                    [5, 1],
-                                                    [12, 3]
-                                                  ]
-                                                }
-                                              }
-                                              }, {
-                                                "id": "boundary-land-level-2",
-                                                "type": "line",
-                                                "source": "openmaptiles",
-                                                "source-layer": "boundary",
-                                                "filter": ["all", ["==", "admin_level", 2],
-                                                ["!=", "maritime", 1],
-                                                ["!=", "disputed", 1]
-                                              ],
-                                              "layout": {
-                                                "line-cap": "round",
-                                                "line-join": "round",
-                                                "visibility": "visible"
-                                              },
-                                              "paint": {
-                                                "line-color": "hsl(248, 7%, 66%)",
-                                                "line-width": {
-                                                  "base": 1,
-                                                  "stops": [
-                                                    [0, 0.6],
-                                                    [4, 1.4],
-                                                    [5, 2],
-                                                    [12, 8]
-                                                  ]
-                                                }
-                                              }
-                                              }, {
-                                                "id": "boundary-land-disputed",
-                                                "type": "line",
-                                                "source": "openmaptiles",
-                                                "source-layer": "boundary",
-                                                "filter": ["all", ["!=", "maritime", 1],
-                                                ["==", "disputed", 1]
-                                              ],
-                                              "layout": {
-                                                "line-cap": "round",
-                                                "line-join": "round",
-                                                "visibility": "visible"
-                                              },
-                                              "paint": {
-                                                "line-color": "hsl(248, 7%, 70%)",
-                                                "line-dasharray": [1, 3],
-                                                "line-width": {
-                                                  "base": 1,
-                                                  "stops": [
-                                                    [0, 0.6],
-                                                    [4, 1.4],
-                                                    [5, 2],
-                                                    [12, 8]
-                                                  ]
-                                                }
-                                              }
-                                              }, {
-                                                "id": "boundary-water",
-                                                "type": "line",
-                                                "source": "openmaptiles",
-                                                "source-layer": "boundary",
-                                                "minzoom": 4,
-                                                "filter": ["all", ["in", "admin_level", 2, 4],
-                                                ["==", "maritime", 1]
-                                              ],
-                                              "layout": {
-                                                "line-cap": "round",
-                                                "line-join": "round",
-                                                "visibility": "visible"
-                                              },
-                                              "paint": {
-                                                "line-color": "rgba(154, 189, 214, 1)",
-                                                "line-opacity": {
-                                                  "stops": [
-                                                    [6, 0.6],
-                                                    [10, 1]
-                                                  ]
-                                                },
-                                                "line-width": {
-                                                  "base": 1,
-                                                  "stops": [
-                                                    [0, 0.6],
-                                                    [4, 1.4],
-                                                    [5, 2],
-                                                    [12, 8]
-                                                  ]
-                                                }
-                                              }
-                                              }, {
-                                                "id": "waterway-name",
-                                                "type": "symbol",
-                                                "source": "openmaptiles",
-                                                "source-layer": "waterway",
-                                                "minzoom": 13,
-                                                "filter": ["all", ["==", "$type", "LineString"],
-                                                ["has", "name"]
-                                              ],
-                                              "layout": {
-                                                "symbol-placement": "line",
-                                                "symbol-spacing": 350,
-                                                "text-field": "{name:latin} {name:nonlatin}",
-                                                "text-font": ["Noto Sans Italic"],
-                                                "text-letter-spacing": 0.2,
-                                                "text-max-width": 5,
-                                                "text-rotation-alignment": "map",
-                                                "text-size": 14
-                                              },
-                                              "paint": {
-                                                "text-color": "#74aee9",
-                                                "text-halo-color": "rgba(255,255,255,0.7)",
-                                                "text-halo-width": 1.5
-                                              }
-                                              }, {
-                                                "id": "water-name-lakeline",
-                                                "type": "symbol",
-                                                "source": "openmaptiles",
-                                                "source-layer": "water_name",
-                                                "filter": ["==", "$type", "LineString"],
-                                                "layout": {
-                                                  "symbol-placement": "line",
-                                                  "symbol-spacing": 350,
-                                                  "text-field": "{name:latin}\n{name:nonlatin}",
-                                                  "text-font": ["Noto Sans Italic"],
-                                                  "text-letter-spacing": 0.2,
-                                                  "text-max-width": 5,
-                                                  "text-rotation-alignment": "map",
-                                                  "text-size": 14
-                                                },
-                                                "paint": {
-                                                  "text-color": "#74aee9",
-                                                  "text-halo-color": "rgba(255,255,255,0.7)",
-                                                  "text-halo-width": 1.5
-                                                }
-                                                }, {
-                                                  "id": "water-name-ocean",
-                                                  "type": "symbol",
-                                                  "source": "openmaptiles",
-                                                  "source-layer": "water_name",
-                                                  "filter": ["all", ["==", "$type", "Point"],
-                                                  ["==", "class", "ocean"]
-                                                ],
-                                                "layout": {
-                                                  "symbol-placement": "point",
-                                                  "symbol-spacing": 350,
-                                                  "text-field": "{name:latin}",
-                                                  "text-font": ["Noto Sans Italic"],
-                                                  "text-letter-spacing": 0.2,
-                                                  "text-max-width": 5,
-                                                  "text-rotation-alignment": "map",
-                                                  "text-size": 14
-                                                },
-                                                "paint": {
-                                                  "text-color": "#74aee9",
-                                                  "text-halo-color": "rgba(255,255,255,0.7)",
-                                                  "text-halo-width": 1.5
-                                                }
-                                                }, {
-                                                  "id": "water-name-other",
-                                                  "type": "symbol",
-                                                  "source": "openmaptiles",
-                                                  "source-layer": "water_name",
-                                                  "filter": ["all", ["==", "$type", "Point"],
-                                                  ["!in", "class", "ocean"]
-                                                ],
-                                                "layout": {
-                                                  "symbol-placement": "point",
-                                                  "symbol-spacing": 350,
-                                                  "text-field": "{name:latin}\n{name:nonlatin}",
-                                                  "text-font": ["Noto Sans Italic"],
-                                                  "text-letter-spacing": 0.2,
-                                                  "text-max-width": 5,
-                                                  "text-rotation-alignment": "map",
-                                                  "text-size": {
-                                                    "stops": [
-                                                      [0, 10],
-                                                      [6, 14]
-                                                    ]
-                                                  },
-                                                  "visibility": "visible"
-                                                },
-                                                "paint": {
-                                                  "text-color": "#74aee9",
-                                                  "text-halo-color": "rgba(255,255,255,0.7)",
-                                                  "text-halo-width": 1.5
-                                                }
-                                                }, {
-                                                  "id": "poi-level-3",
-                                                  "type": "symbol",
-                                                  "source": "openmaptiles",
-                                                  "source-layer": "poi",
-                                                  "minzoom": 16,
-                                                  "filter": ["all", ["==", "$type", "Point"],
-                                                  [">=", "rank", 25],
-                                                  ["any", ["!has", "level"],
-                                                  ["==", "level", 0]
-                                                ]
-                                              ],
-                                              "layout": {
-                                                "icon-image": "{class}_11",
-                                                "text-anchor": "top",
-                                                "text-field": "{name:latin}\n{name:nonlatin}",
-                                                "text-font": ["Noto Sans Regular"],
-                                                "text-max-width": 9,
-                                                "text-offset": [0, 0.6],
-                                                "text-padding": 2,
-                                                "text-size": 12,
-                                                "visibility": "visible"
-                                              },
-                                              "paint": {
-                                                "text-color": "#666",
-                                                "text-halo-blur": 0.5,
-                                                "text-halo-color": "#ffffff",
-                                                "text-halo-width": 1
-                                              }
-                                              }, {
-                                                "id": "poi-level-2",
-                                                "type": "symbol",
-                                                "source": "openmaptiles",
-                                                "source-layer": "poi",
-                                                "minzoom": 15,
-                                                "filter": ["all", ["==", "$type", "Point"],
-                                                ["<=", "rank", 24],
-                                                [">=", "rank", 15],
-                                                ["any", ["!has", "level"],
-                                                ["==", "level", 0]
-                                              ]
-                                            ],
-                                            "layout": {
-                                              "icon-image": "{class}_11",
-                                              "text-anchor": "top",
-                                              "text-field": "{name:latin}\n{name:nonlatin}",
-                                              "text-font": ["Noto Sans Regular"],
-                                              "text-max-width": 9,
-                                              "text-offset": [0, 0.6],
-                                              "text-padding": 2,
-                                              "text-size": 12,
-                                              "visibility": "visible"
-                                            },
-                                            "paint": {
-                                              "text-color": "#666",
-                                              "text-halo-blur": 0.5,
-                                              "text-halo-color": "#ffffff",
-                                              "text-halo-width": 1
-                                            }
-                                            }, {
-                                              "id": "poi-level-1",
-                                              "type": "symbol",
-                                              "source": "openmaptiles",
-                                              "source-layer": "poi",
-                                              "minzoom": 14,
-                                              "filter": ["all", ["==", "$type", "Point"],
-                                              ["<=", "rank", 14],
-                                              ["has", "name"],
-                                              ["any", ["!has", "level"],
-                                              ["==", "level", 0]
-                                            ]
-                                          ],
-                                          "layout": {
-                                            "icon-image": "{class}_11",
-                                            "text-anchor": "top",
-                                            "text-field": "{name:latin}\n{name:nonlatin}",
-                                            "text-font": ["Noto Sans Regular"],
-                                            "text-max-width": 9,
-                                            "text-offset": [0, 0.6],
-                                            "text-padding": 2,
-                                            "text-size": 12,
-                                            "visibility": "visible"
-                                          },
-                                          "paint": {
-                                            "text-color": "#666",
-                                            "text-halo-blur": 0.5,
-                                            "text-halo-color": "#ffffff",
-                                            "text-halo-width": 1
-                                          }
-                                          }, {
-                                            "id": "poi-railway",
-                                            "type": "symbol",
-                                            "source": "openmaptiles",
-                                            "source-layer": "poi",
-                                            "minzoom": 13,
-                                            "filter": ["all", ["==", "$type", "Point"],
-                                            ["has", "name"],
-                                            ["==", "class", "railway"],
-                                            ["==", "subclass", "station"]
-                                          ],
-                                          "layout": {
-                                            "icon-allow-overlap": false,
-                                            "icon-ignore-placement": false,
-                                            "icon-image": "{class}_11",
-                                            "icon-optional": false,
-                                            "text-allow-overlap": false,
-                                            "text-anchor": "top",
-                                            "text-field": "{name:latin}\n{name:nonlatin}",
-                                            "text-font": ["Noto Sans Regular"],
-                                            "text-ignore-placement": false,
-                                            "text-max-width": 9,
-                                            "text-offset": [0, 0.6],
-                                            "text-optional": true,
-                                            "text-padding": 2,
-                                            "text-size": 12
-                                          },
-                                          "paint": {
-                                            "text-color": "#666",
-                                            "text-halo-blur": 0.5,
-                                            "text-halo-color": "#ffffff",
-                                            "text-halo-width": 1
-                                          }
-                                          }, {
-                                            "id": "road_oneway",
-                                            "type": "symbol",
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "minzoom": 15,
-                                            "filter": ["all", ["==", "oneway", 1],
-                                            ["in", "class", "motorway", "trunk", "primary", "secondary", "tertiary", "minor", "service"]
-                                          ],
-                                          "layout": {
-                                            "icon-image": "oneway",
-                                            "icon-padding": 2,
-                                            "icon-rotate": 90,
-                                            "icon-rotation-alignment": "map",
-                                            "icon-size": {
-                                              "stops": [
-                                                [15, 0.5],
-                                                [19, 1]
-                                              ]
-                                            },
-                                            "symbol-placement": "line",
-                                            "symbol-spacing": 75
-                                          },
-                                          "paint": {
-                                            "icon-opacity": 0.5
-                                          }
-                                          }, {
-                                            "id": "road_oneway_opposite",
-                                            "type": "symbol",
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation",
-                                            "minzoom": 15,
-                                            "filter": ["all", ["==", "oneway", -1],
-                                            ["in", "class", "motorway", "trunk", "primary", "secondary", "tertiary", "minor", "service"]
-                                          ],
-                                          "layout": {
-                                            "icon-image": "oneway",
-                                            "icon-padding": 2,
-                                            "icon-rotate": -90,
-                                            "icon-rotation-alignment": "map",
-                                            "icon-size": {
-                                              "stops": [
-                                                [15, 0.5],
-                                                [19, 1]
-                                              ]
-                                            },
-                                            "symbol-placement": "line",
-                                            "symbol-spacing": 75
-                                          },
-                                          "paint": {
-                                            "icon-opacity": 0.5
-                                          }
-                                          }, {
-                                            "id": "highway-name-path",
-                                            "type": "symbol",
-                                            "source": "openmaptiles",
-                                            "source-layer": "transportation_name",
-                                            "minzoom": 15.5,
-                                            "filter": ["==", "class", "path"],
-                                            "layout": {
-                                              "symbol-placement": "line",
-                                              "text-field": "{name:latin} {name:nonlatin}",
-                                              "text-font": ["Noto Sans Regular"],
-                                              "text-rotation-alignment": "map",
-                                              "text-size": {
-                                                "base": 1,
-                                                "stops": [
-                                                  [13, 12],
-                                                  [14, 13]
-                                                ]
-                                              }
-                                            },
-                                            "paint": {
-                                              "text-color": "hsl(30, 23%, 62%)",
-                                              "text-halo-color": "#f8f4f0",
-                                              "text-halo-width": 0.5
-                                            }
-                                            }, {
-                                              "id": "highway-name-minor",
-                                              "type": "symbol",
-                                              "source": "openmaptiles",
-                                              "source-layer": "transportation_name",
-                                              "minzoom": 15,
-                                              "filter": ["all", ["==", "$type", "LineString"],
-                                              ["in", "class", "minor", "service", "track"]
-                                            ],
-                                            "layout": {
-                                              "symbol-placement": "line",
-                                              "text-field": "{name:latin} {name:nonlatin}",
-                                              "text-font": ["Noto Sans Regular"],
-                                              "text-rotation-alignment": "map",
-                                              "text-size": {
-                                                "base": 1,
-                                                "stops": [
-                                                  [13, 12],
-                                                  [14, 13]
-                                                ]
-                                              }
-                                            },
-                                            "paint": {
-                                              "text-color": "#765",
-                                              "text-halo-blur": 0.5,
-                                              "text-halo-width": 1
-                                            }
-                                            }, {
-                                              "id": "highway-name-major",
-                                              "type": "symbol",
-                                              "source": "openmaptiles",
-                                              "source-layer": "transportation_name",
-                                              "minzoom": 12.2,
-                                              "filter": ["in", "class", "primary", "secondary", "tertiary", "trunk"],
-                                              "layout": {
-                                                "symbol-placement": "line",
-                                                "text-field": "{name:latin} {name:nonlatin}",
-                                                "text-font": ["Noto Sans Regular"],
-                                                "text-rotation-alignment": "map",
-                                                "text-size": {
-                                                  "base": 1,
-                                                  "stops": [
-                                                    [13, 12],
-                                                    [14, 13]
-                                                  ]
-                                                }
-                                              },
-                                              "paint": {
-                                                "text-color": "#765",
-                                                "text-halo-blur": 0.5,
-                                                "text-halo-width": 1
-                                              }
-                                              }, {
-                                                "id": "highway-shield",
-                                                "type": "symbol",
-                                                "source": "openmaptiles",
-                                                "source-layer": "transportation_name",
-                                                "minzoom": 8,
-                                                "filter": ["all", ["<=", "ref_length", 6],
-                                                ["==", "$type", "LineString"],
-                                                ["!in", "network", "us-interstate", "us-highway", "us-state"]
-                                              ],
-                                              "layout": {
-                                                "icon-image": "road_{ref_length}",
-                                                "icon-rotation-alignment": "viewport",
-                                                "icon-size": 1,
-                                                "symbol-placement": {
-                                                  "base": 1,
-                                                  "stops": [
-                                                    [10, "point"],
-                                                    [11, "line"]
-                                                  ]
-                                                },
-                                                "symbol-spacing": 200,
-                                                "text-field": "{ref}",
-                                                "text-font": ["Noto Sans Regular"],
-                                                "text-rotation-alignment": "viewport",
-                                                "text-size": 10
-                                              },
-                                              "paint": {}
-                                              }, {
-                                                "id": "highway-shield-us-interstate",
-                                                "type": "symbol",
-                                                "source": "openmaptiles",
-                                                "source-layer": "transportation_name",
-                                                "minzoom": 7,
-                                                "filter": ["all", ["<=", "ref_length", 6],
-                                                ["==", "$type", "LineString"],
-                                                ["in", "network", "us-interstate"]
-                                              ],
-                                              "layout": {
-                                                "icon-image": "{network}_{ref_length}",
-                                                "icon-rotation-alignment": "viewport",
-                                                "icon-size": 1,
-                                                "symbol-placement": {
-                                                  "base": 1,
-                                                  "stops": [
-                                                    [7, "point"],
-                                                    [7, "line"],
-                                                    [8, "line"]
-                                                  ]
-                                                },
-                                                "symbol-spacing": 200,
-                                                "text-field": "{ref}",
-                                                "text-font": ["Noto Sans Regular"],
-                                                "text-rotation-alignment": "viewport",
-                                                "text-size": 10
-                                              },
-                                              "paint": {
-                                                "text-color": "rgba(0, 0, 0, 1)"
-                                              }
-                                              }, {
-                                                "id": "highway-shield-us-other",
-                                                "type": "symbol",
-                                                "source": "openmaptiles",
-                                                "source-layer": "transportation_name",
-                                                "minzoom": 9,
-                                                "filter": ["all", ["<=", "ref_length", 6],
-                                                ["==", "$type", "LineString"],
-                                                ["in", "network", "us-highway", "us-state"]
-                                              ],
-                                              "layout": {
-                                                "icon-image": "{network}_{ref_length}",
-                                                "icon-rotation-alignment": "viewport",
-                                                "icon-size": 1,
-                                                "symbol-placement": {
-                                                  "base": 1,
-                                                  "stops": [
-                                                    [10, "point"],
-                                                    [11, "line"]
-                                                  ]
-                                                },
-                                                "symbol-spacing": 200,
-                                                "text-field": "{ref}",
-                                                "text-font": ["Noto Sans Regular"],
-                                                "text-rotation-alignment": "viewport",
-                                                "text-size": 10
-                                              },
-                                              "paint": {
-                                                "text-color": "rgba(0, 0, 0, 1)"
-                                              }
-                                              }, {
-                                                "id": "airport-label-major",
-                                                "type": "symbol",
-                                                "source": "openmaptiles",
-                                                "source-layer": "aerodrome_label",
-                                                "minzoom": 10,
-                                                "filter": ["all", ["has", "iata"]],
-                                                "layout": {
-                                                  "icon-image": "airport_11",
-                                                  "icon-size": 1,
-                                                  "text-anchor": "top",
-                                                  "text-field": "{name:latin}\n{name:nonlatin}",
-                                                  "text-font": ["Noto Sans Regular"],
-                                                  "text-max-width": 9,
-                                                  "text-offset": [0, 0.6],
-                                                  "text-optional": true,
-                                                  "text-padding": 2,
-                                                  "text-size": 12,
-                                                  "visibility": "visible"
-                                                },
-                                                "paint": {
-                                                  "text-color": "#666",
-                                                  "text-halo-blur": 0.5,
-                                                  "text-halo-color": "#ffffff",
-                                                  "text-halo-width": 1
-                                                }
-                                                }, {
-                                                  "id": "place-other",
-                                                  "type": "symbol",
-                                                  "metadata": {
-                                                    "mapbox:group": "1444849242106.713"
-                                                  },
-                                                  "source": "openmaptiles",
-                                                  "source-layer": "place",
-                                                  "filter": ["!in", "class", "city", "town", "village", "state", "country", "continent"],
-                                                  "layout": {
-                                                    "text-field": "{name:latin}\n{name:nonlatin}",
-                                                    "text-font": ["Noto Sans Bold"],
-                                                    "text-letter-spacing": 0.1,
-                                                    "text-max-width": 9,
-                                                    "text-size": {
-                                                      "base": 1.2,
-                                                      "stops": [
-                                                        [12, 10],
-                                                        [15, 14]
-                                                      ]
-                                                    },
-                                                    "text-transform": "uppercase",
-                                                    "visibility": "visible"
-                                                  },
-                                                  "paint": {
-                                                    "text-color": "#633",
-                                                    "text-halo-color": "rgba(255,255,255,0.8)",
-                                                    "text-halo-width": 1.2
-                                                  }
-                                                  }, {
-                                                    "id": "place-village",
-                                                    "type": "symbol",
-                                                    "metadata": {
-                                                      "mapbox:group": "1444849242106.713"
-                                                    },
-                                                    "source": "openmaptiles",
-                                                    "source-layer": "place",
-                                                    "filter": ["==", "class", "village"],
-                                                    "layout": {
-                                                      "text-field": "{name:latin}\n{name:nonlatin}",
-                                                      "text-font": ["Noto Sans Regular"],
-                                                      "text-max-width": 8,
-                                                      "text-size": {
-                                                        "base": 1.2,
-                                                        "stops": [
-                                                          [10, 12],
-                                                          [15, 22]
-                                                        ]
-                                                      },
-                                                      "visibility": "visible"
-                                                    },
-                                                    "paint": {
-                                                      "text-color": "#333",
-                                                      "text-halo-color": "rgba(255,255,255,0.8)",
-                                                      "text-halo-width": 1.2
-                                                    }
-                                                    }, {
-                                                      "id": "place-town",
-                                                      "type": "symbol",
-                                                      "metadata": {
-                                                        "mapbox:group": "1444849242106.713"
-                                                      },
-                                                      "source": "openmaptiles",
-                                                      "source-layer": "place",
-                                                      "filter": ["==", "class", "town"],
-                                                      "layout": {
-                                                        "text-field": "{name:latin}\n{name:nonlatin}",
-                                                        "text-font": ["Noto Sans Regular"],
-                                                        "text-max-width": 8,
-                                                        "text-size": {
-                                                          "base": 1.2,
-                                                          "stops": [
-                                                            [10, 14],
-                                                            [15, 24]
-                                                          ]
-                                                        },
-                                                        "visibility": "visible"
-                                                      },
-                                                      "paint": {
-                                                        "text-color": "#333",
-                                                        "text-halo-color": "rgba(255,255,255,0.8)",
-                                                        "text-halo-width": 1.2
-                                                      }
-                                                      }, {
-                                                        "id": "place-city",
-                                                        "type": "symbol",
-                                                        "metadata": {
-                                                          "mapbox:group": "1444849242106.713"
-                                                        },
-                                                        "source": "openmaptiles",
-                                                        "source-layer": "place",
-                                                        "filter": ["all", ["!=", "capital", 2],
-                                                        ["==", "class", "city"]
-                                                      ],
-                                                      "layout": {
-                                                        "text-field": "{name:latin}\n{name:nonlatin}",
-                                                        "text-font": ["Noto Sans Regular"],
-                                                        "text-max-width": 8,
-                                                        "text-size": {
-                                                          "base": 1.2,
-                                                          "stops": [
-                                                            [7, 14],
-                                                            [11, 24]
-                                                          ]
-                                                        },
-                                                        "visibility": "visible"
-                                                      },
-                                                      "paint": {
-                                                        "text-color": "#333",
-                                                        "text-halo-color": "rgba(255,255,255,0.8)",
-                                                        "text-halo-width": 1.2
-                                                      }
-                                                      }, {
-                                                        "id": "place-city-capital",
-                                                        "type": "symbol",
-                                                        "metadata": {
-                                                          "mapbox:group": "1444849242106.713"
-                                                        },
-                                                        "source": "openmaptiles",
-                                                        "source-layer": "place",
-                                                        "filter": ["all", ["==", "capital", 2],
-                                                        ["==", "class", "city"]
-                                                      ],
-                                                      "layout": {
-                                                        "icon-image": "star_11",
-                                                        "icon-size": 0.8,
-                                                        "text-anchor": "left",
-                                                        "text-field": "{name:latin}\n{name:nonlatin}",
-                                                        "text-font": ["Noto Sans Regular"],
-                                                        "text-max-width": 8,
-                                                        "text-offset": [0.4, 0],
-                                                        "text-size": {
-                                                          "base": 1.2,
-                                                          "stops": [
-                                                            [7, 14],
-                                                            [11, 24]
-                                                          ]
-                                                        },
-                                                        "visibility": "visible"
-                                                      },
-                                                      "paint": {
-                                                        "text-color": "#333",
-                                                        "text-halo-color": "rgba(255,255,255,0.8)",
-                                                        "text-halo-width": 1.2
-                                                      }
-                                                      }, {
-                                                        "id": "place-state",
-                                                        "type": "symbol",
-                                                        "metadata": {
-                                                          "mapbox:group": "1444849242106.713"
-                                                        },
-                                                        "source": "openmaptiles",
-                                                        "source-layer": "place",
-                                                        "filter": ["in", "class", "state"],
-                                                        "layout": {
-                                                          "text-field": "{name:latin}",
-                                                          "text-font": ["Noto Sans Bold"],
-                                                          "text-letter-spacing": 0.1,
-                                                          "text-max-width": 9,
-                                                          "text-size": {
-                                                            "base": 1.2,
-                                                            "stops": [
-                                                              [12, 10],
-                                                              [15, 14]
-                                                            ]
-                                                          },
-                                                          "text-transform": "uppercase",
-                                                          "visibility": "visible"
-                                                        },
-                                                        "paint": {
-                                                          "text-color": "#633",
-                                                          "text-halo-color": "rgba(255,255,255,0.8)",
-                                                          "text-halo-width": 1.2
-                                                        }
-                                                        }, {
-                                                          "id": "place-country-other",
-                                                          "type": "symbol",
-                                                          "metadata": {
-                                                            "mapbox:group": "1444849242106.713"
-                                                          },
-                                                          "source": "openmaptiles",
-                                                          "source-layer": "place",
-                                                          "filter": ["all", ["==", "class", "country"],
-                                                          [">=", "rank", 3],
-                                                          ["!has", "iso_a2"]
-                                                        ],
-                                                        "layout": {
-                                                          "text-field": "{name:latin}",
-                                                          "text-font": ["Noto Sans Italic"],
-                                                          "text-max-width": 6.25,
-                                                          "text-size": {
-                                                            "stops": [
-                                                              [3, 11],
-                                                              [7, 17]
-                                                            ]
-                                                          },
-                                                          "text-transform": "uppercase",
-                                                          "visibility": "visible"
-                                                        },
-                                                        "paint": {
-                                                          "text-color": "#334",
-                                                          "text-halo-blur": 1,
-                                                          "text-halo-color": "rgba(255,255,255,0.8)",
-                                                          "text-halo-width": 2
-                                                        }
-                                                        }, {
-                                                          "id": "place-country-3",
-                                                          "type": "symbol",
-                                                          "metadata": {
-                                                            "mapbox:group": "1444849242106.713"
-                                                          },
-                                                          "source": "openmaptiles",
-                                                          "source-layer": "place",
-                                                          "filter": ["all", ["==", "class", "country"],
-                                                          [">=", "rank", 3],
-                                                          ["has", "iso_a2"]
-                                                        ],
-                                                        "layout": {
-                                                          "text-field": "{name:latin}",
-                                                          "text-font": ["Noto Sans Bold"],
-                                                          "text-max-width": 6.25,
-                                                          "text-size": {
-                                                            "stops": [
-                                                              [3, 11],
-                                                              [7, 17]
-                                                            ]
-                                                          },
-                                                          "text-transform": "uppercase",
-                                                          "visibility": "visible"
-                                                        },
-                                                        "paint": {
-                                                          "text-color": "#334",
-                                                          "text-halo-blur": 1,
-                                                          "text-halo-color": "rgba(255,255,255,0.8)",
-                                                          "text-halo-width": 2
-                                                        }
-                                                        }, {
-                                                          "id": "place-country-2",
-                                                          "type": "symbol",
-                                                          "metadata": {
-                                                            "mapbox:group": "1444849242106.713"
-                                                          },
-                                                          "source": "openmaptiles",
-                                                          "source-layer": "place",
-                                                          "filter": ["all", ["==", "class", "country"],
-                                                          ["==", "rank", 2],
-                                                          ["has", "iso_a2"]
-                                                        ],
-                                                        "layout": {
-                                                          "text-field": "{name:latin}",
-                                                          "text-font": ["Noto Sans Bold"],
-                                                          "text-max-width": 6.25,
-                                                          "text-size": {
-                                                            "stops": [
-                                                              [2, 11],
-                                                              [5, 17]
-                                                            ]
-                                                          },
-                                                          "text-transform": "uppercase",
-                                                          "visibility": "visible"
-                                                        },
-                                                        "paint": {
-                                                          "text-color": "#334",
-                                                          "text-halo-blur": 1,
-                                                          "text-halo-color": "rgba(255,255,255,0.8)",
-                                                          "text-halo-width": 2
-                                                        }
-                                                        }, {
-                                                          "id": "place-country-1",
-                                                          "type": "symbol",
-                                                          "metadata": {
-                                                            "mapbox:group": "1444849242106.713"
-                                                          },
-                                                          "source": "openmaptiles",
-                                                          "source-layer": "place",
-                                                          "filter": ["all", ["==", "class", "country"],
-                                                          ["==", "rank", 1],
-                                                          ["has", "iso_a2"]
-                                                        ],
-                                                        "layout": {
-                                                          "text-field": "{name:latin}",
-                                                          "text-font": ["Noto Sans Bold"],
-                                                          "text-max-width": 6.25,
-                                                          "text-size": {
-                                                            "stops": [
-                                                              [1, 11],
-                                                              [4, 17]
-                                                            ]
-                                                          },
-                                                          "text-transform": "uppercase",
-                                                          "visibility": "visible"
-                                                        },
-                                                        "paint": {
-                                                          "text-color": "#334",
-                                                          "text-halo-blur": 1,
-                                                          "text-halo-color": "rgba(255,255,255,0.8)",
-                                                          "text-halo-width": 2
-                                                        }
-                                                        }, {
-                                                          "id": "place-continent",
-                                                          "type": "symbol",
-                                                          "metadata": {
-                                                            "mapbox:group": "1444849242106.713"
-                                                          },
-                                                          "source": "openmaptiles",
-                                                          "source-layer": "place",
-                                                          "maxzoom": 1,
-                                                          "filter": ["==", "class", "continent"],
-                                                          "layout": {
-                                                            "text-field": "{name:latin}",
-                                                            "text-font": ["Noto Sans Bold"],
-                                                            "text-max-width": 6.25,
-                                                            "text-size": 14,
-                                                            "text-transform": "uppercase",
-                                                            "visibility": "visible"
-                                                          },
-                                                          "paint": {
-                                                            "text-color": "#334",
-                                                            "text-halo-blur": 1,
-                                                            "text-halo-color": "rgba(255,255,255,0.8)",
-                                                            "text-halo-width": 2
-                                                          }
-                                                          }],
-                                                          "id": "bright"
-                                                        }
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10
+      },
+      "paint": {}
+    },
+    {
+      "id": "highway-shield-us-interstate",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "network",
+          "us-interstate"
+        ]
+      ],
+      "layout": {
+        "icon-image": "{network}_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              7,
+              "point"
+            ],
+            [
+              7,
+              "line"
+            ],
+            [
+              8,
+              "line"
+            ]
+          ]
+        },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10
+      },
+      "paint": {
+        "text-color": "rgba(0, 0, 0, 1)"
+      }
+    },
+    {
+      "id": "highway-shield-us-other",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 9,
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "network",
+          "us-highway",
+          "us-state"
+        ]
+      ],
+      "layout": {
+        "icon-image": "{network}_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              10,
+              "point"
+            ],
+            [
+              11,
+              "line"
+            ]
+          ]
+        },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10
+      },
+      "paint": {
+        "text-color": "rgba(0, 0, 0, 1)"
+      }
+    },
+    {
+      "id": "airport-label-major",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "aerodrome_label",
+      "minzoom": 10,
+      "filter": [
+        "all",
+        [
+          "has",
+          "iata"
+        ]
+      ],
+      "layout": {
+        "icon-image": "airport_11",
+        "icon-size": 1,
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.6
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "place-other",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "!in",
+        "class",
+        "city",
+        "town",
+        "village",
+        "state",
+        "country",
+        "continent"
+      ],
+      "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Bold"
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 9,
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              15,
+              14
+            ]
+          ]
+        },
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#633",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-village",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "==",
+        "class",
+        "village"
+      ],
+      "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              10,
+              12
+            ],
+            [
+              15,
+              22
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-town",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "==",
+        "class",
+        "town"
+      ],
+      "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              10,
+              14
+            ],
+            [
+              15,
+              24
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-city",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        [
+          "!=",
+          "capital",
+          2
+        ],
+        [
+          "==",
+          "class",
+          "city"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              7,
+              14
+            ],
+            [
+              11,
+              24
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-city-capital",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        [
+          "==",
+          "capital",
+          2
+        ],
+        [
+          "==",
+          "class",
+          "city"
+        ]
+      ],
+      "layout": {
+        "icon-image": "star_11",
+        "icon-size": 0.8,
+        "text-anchor": "left",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0.4,
+          0
+        ],
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              7,
+              14
+            ],
+            [
+              11,
+              24
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-state",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "in",
+        "class",
+        "state"
+      ],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": [
+          "Noto Sans Bold"
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 9,
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              15,
+              14
+            ]
+          ]
+        },
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#633",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-country-other",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          ">=",
+          "rank",
+          3
+        ],
+        [
+          "!has",
+          "iso_a2"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-max-width": 6.25,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              7,
+              17
+            ]
+          ]
+        },
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "place-country-3",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          ">=",
+          "rank",
+          3
+        ],
+        [
+          "has",
+          "iso_a2"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": [
+          "Noto Sans Bold"
+        ],
+        "text-max-width": 6.25,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              7,
+              17
+            ]
+          ]
+        },
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "place-country-2",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          "==",
+          "rank",
+          2
+        ],
+        [
+          "has",
+          "iso_a2"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": [
+          "Noto Sans Bold"
+        ],
+        "text-max-width": 6.25,
+        "text-size": {
+          "stops": [
+            [
+              2,
+              11
+            ],
+            [
+              5,
+              17
+            ]
+          ]
+        },
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "place-country-1",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          "==",
+          "rank",
+          1
+        ],
+        [
+          "has",
+          "iso_a2"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": [
+          "Noto Sans Bold"
+        ],
+        "text-max-width": 6.25,
+        "text-size": {
+          "stops": [
+            [
+              1,
+              11
+            ],
+            [
+              4,
+              17
+            ]
+          ]
+        },
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "place-continent",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 1,
+      "filter": [
+        "==",
+        "class",
+        "continent"
+      ],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": [
+          "Noto Sans Bold"
+        ],
+        "text-max-width": 6.25,
+        "text-size": 14,
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
+      }
+    }
+  ]
+}

--- a/src/map-styles/plan.json
+++ b/src/map-styles/plan.json
@@ -1,0 +1,4455 @@
+{
+  "version": 8,
+  "name": "Plan",
+  "id": "plan",
+  "metadata": {
+    "mapbox:autocomposite": false,
+    "mapbox:groups": {
+      "1444849242106.713": {
+        "collapsed": false,
+        "name": "Places"
+      },
+      "1444849334699.1902": {
+        "collapsed": true,
+        "name": "Bridges"
+      },
+      "1444849345966.4436": {
+        "collapsed": false,
+        "name": "Roads"
+      },
+      "1444849354174.1904": {
+        "collapsed": true,
+        "name": "Tunnels"
+      },
+      "1444849364238.8171": {
+        "collapsed": false,
+        "name": "Buildings"
+      },
+      "1444849382550.77": {
+        "collapsed": false,
+        "name": "Water"
+      },
+      "1444849388993.3071": {
+        "collapsed": false,
+        "name": "Land"
+      }
+    },
+    "mapbox:type": "template",
+    "openmaptiles:mapbox:owner": "openmaptiles",
+    "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t",
+    "openmaptiles:version": "3.x"
+  },
+  "center": [
+    0,
+    0
+  ],
+  "zoom": 1,
+  "bearing": 0,
+  "pitch": 0,
+  "sources": {
+    "openmaptiles": {
+      "type": "vector",
+      "url": "https://openmaptiles.geo.data.gouv.fr/data/france-vector.json"
+    }
+  },
+  "sprite": "https://openmaptiles.github.io/osm-bright-gl-style/sprite",
+  "glyphs": "https://openmaptiles.geo.data.gouv.fr/fonts/{fontstack}/{range}.pbf",
+  "layers": [
+    {
+      "id": "landcover-glacier",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": [
+        "==",
+        "subclass",
+        "glacier"
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "#fff",
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.9
+            ],
+            [
+              10,
+              0.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "landuse-residential",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "residential",
+          "suburb",
+          "neighbourhood"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": {
+          "base": 1,
+          "stops": [
+            [
+              12,
+              "hsla(30, 19%, 90%, 0.4)"
+            ],
+            [
+              16,
+              "hsla(30, 19%, 90%, 0.2)"
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "landuse-commercial",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "class",
+          "commercial"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsla(0, 60%, 87%, 0.23)"
+      }
+    },
+    {
+      "id": "landuse-industrial",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "in",
+          "class",
+          "industrial",
+          "garages",
+          "dam"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsla(49, 100%, 88%, 0.34)"
+      }
+    },
+    {
+      "id": "landuse-cemetery",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": [
+        "==",
+        "class",
+        "cemetery"
+      ],
+      "paint": {
+        "fill-color": "#e0e4dd"
+      }
+    },
+    {
+      "id": "landuse-hospital",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": [
+        "==",
+        "class",
+        "hospital"
+      ],
+      "paint": {
+        "fill-color": "#fde"
+      }
+    },
+    {
+      "id": "landuse-school",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": [
+        "==",
+        "class",
+        "school"
+      ],
+      "paint": {
+        "fill-color": "#f0e8f8"
+      }
+    },
+    {
+      "id": "landuse-railway",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": [
+        "==",
+        "class",
+        "railway"
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsla(30, 19%, 90%, 0.4)"
+      }
+    },
+    {
+      "id": "landcover-wood",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": [
+        "==",
+        "class",
+        "wood"
+      ],
+      "paint": {
+        "fill-antialias": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              false
+            ],
+            [
+              9,
+              true
+            ]
+          ]
+        },
+        "fill-color": "#6a4",
+        "fill-opacity": 0.1,
+        "fill-outline-color": "hsla(0, 0%, 0%, 0.03)"
+      }
+    },
+    {
+      "id": "landcover-grass",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": [
+        "==",
+        "class",
+        "grass"
+      ],
+      "paint": {
+        "fill-color": "#d8e8c8",
+        "fill-opacity": 1
+      }
+    },
+    {
+      "id": "landcover-grass-park",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "source": "openmaptiles",
+      "source-layer": "park",
+      "filter": [
+        "==",
+        "class",
+        "public_park"
+      ],
+      "paint": {
+        "fill-color": "#d8e8c8",
+        "fill-opacity": 0.8
+      }
+    },
+    {
+      "id": "waterway_tunnel",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "river",
+          "stream",
+          "canal"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-dasharray": [
+          2,
+          4
+        ],
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterway-other",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "!in",
+          "class",
+          "canal",
+          "river",
+          "stream"
+        ],
+        [
+          "==",
+          "intermittent",
+          0
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterway-other-intermittent",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "!in",
+          "class",
+          "canal",
+          "river",
+          "stream"
+        ],
+        [
+          "==",
+          "intermittent",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-dasharray": [
+          4,
+          3
+        ],
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterway-stream-canal",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "canal",
+          "stream"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "intermittent",
+          0
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterway-stream-canal-intermittent",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "canal",
+          "stream"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "intermittent",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-dasharray": [
+          4,
+          3
+        ],
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterway-river",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "river"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "intermittent",
+          0
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              10,
+              0.8
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterway-river-intermittent",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "river"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "intermittent",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-dasharray": [
+          3,
+          2.5
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              10,
+              0.8
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "water-offset",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "maxzoom": 8,
+      "filter": [
+        "==",
+        "$type",
+        "Polygon"
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "#a0c8f0",
+        "fill-opacity": 1,
+        "fill-translate": {
+          "base": 1,
+          "stops": [
+            [
+              6,
+              [
+                2,
+                0
+              ]
+            ],
+            [
+              8,
+              [
+                0,
+                0
+              ]
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "filter": [
+        "all",
+        [
+          "!=",
+          "intermittent",
+          1
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(210, 67%, 85%)"
+      }
+    },
+    {
+      "id": "water-intermittent",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "filter": [
+        "all",
+        [
+          "==",
+          "intermittent",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(210, 67%, 85%)",
+        "fill-opacity": 0.7
+      }
+    },
+    {
+      "id": "water-pattern",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "filter": [
+        "all"
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-pattern": "wave",
+        "fill-translate": [
+          0,
+          2.5
+        ]
+      }
+    },
+    {
+      "id": "landcover-ice-shelf",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": [
+        "==",
+        "subclass",
+        "ice_shelf"
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "#fff",
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.9
+            ],
+            [
+              10,
+              0.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "landcover-sand",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "sand"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "rgba(245, 238, 188, 1)",
+        "fill-opacity": 1
+      }
+    },
+    {
+      "id": "building",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849364238.8171"
+      },
+      "source": "openmaptiles",
+      "source-layer": "building",
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": {
+          "base": 1,
+          "stops": [
+            [
+              15.5,
+              "#f2eae2"
+            ],
+            [
+              16,
+              "#dfdbd7"
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "building-top",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849364238.8171"
+      },
+      "source": "openmaptiles",
+      "source-layer": "building",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "#f2eae2",
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              0
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        },
+        "fill-outline-color": "#dfdbd7",
+        "fill-translate": {
+          "base": 1,
+          "stops": [
+            [
+              14,
+              [
+                0,
+                0
+              ]
+            ],
+            [
+              16,
+              [
+                -2,
+                -2
+              ]
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-service-track-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "service",
+          "track"
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              20,
+              11
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-motorway-link-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(200, 147, 102, 1)",
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-minor-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "minor"
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {
+          "stops": [
+            [
+              12,
+              0
+            ],
+            [
+              12.5,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              13,
+              1
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        },
+        "line-dasharray": [
+          0.5,
+          0.25
+        ]
+      }
+    },
+    {
+      "id": "tunnel-link-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        },
+        "line-dasharray": [
+          0.5,
+          0.25
+        ]
+      }
+    },
+    {
+      "id": "tunnel-secondary-tertiary-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              1.5
+            ],
+            [
+              20,
+              17
+            ]
+          ]
+        },
+        "line-dasharray": [
+          0.5,
+          0.25
+        ]
+      }
+    },
+    {
+      "id": "tunnel-trunk-primary-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-motorway-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-path",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "path"
+        ]
+      ],
+      "paint": {
+        "line-color": "#cba",
+        "line-dasharray": [
+          1.5,
+          0.75
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              4
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-motorway-link",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(244, 209, 158, 1)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-service-track",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "service",
+          "track"
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15.5,
+              0
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              20,
+              7.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-link",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff4c6",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-minor",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "minor_road"
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              13.5,
+              0
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-secondary-tertiary",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff4c6",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              10
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-trunk-primary",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff4c6",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-motorway",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#ffdaa6",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel-railway",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "ferry",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "ferry"
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(108, 159, 182, 1)",
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-width": 1.1
+      }
+    },
+    {
+      "id": "aeroway-taxiway-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "taxiway"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(153, 153, 153, 1)",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              2
+            ],
+            [
+              17,
+              12
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "aeroway-runway-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "runway"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(153, 153, 153, 1)",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              5
+            ],
+            [
+              17,
+              55
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "aeroway-area",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "in",
+          "class",
+          "runway",
+          "taxiway"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "rgba(255, 255, 255, 1)",
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              0
+            ],
+            [
+              14,
+              1
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "aeroway-taxiway",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "taxiway"
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              0
+            ],
+            [
+              12,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              17,
+              10
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "aeroway-runway",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "runway"
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              0
+            ],
+            [
+              12,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              4
+            ],
+            [
+              17,
+              50
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_area_pier",
+      "type": "fill",
+      "metadata": {},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "class",
+          "pier"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "#f8f4f0"
+      }
+    },
+    {
+      "id": "road_pier",
+      "type": "line",
+      "metadata": {},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "pier"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#f8f4f0",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1
+            ],
+            [
+              17,
+              4
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-area",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "!in",
+          "class",
+          "pier"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "hsla(0, 0%, 89%, 0.56)",
+        "fill-opacity": 0.9,
+        "fill-outline-color": "#cfcdca"
+      }
+    },
+    {
+      "id": "highway-motorway-link-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-link-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-minor-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "minor",
+          "service",
+          "track"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {
+          "stops": [
+            [
+              12,
+              0
+            ],
+            [
+              12.5,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              13,
+              1
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-secondary-tertiary-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              1.5
+            ],
+            [
+              20,
+              17
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-primary-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": {
+          "stops": [
+            [
+              7,
+              0
+            ],
+            [
+              8,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              7,
+              0
+            ],
+            [
+              8,
+              0.6
+            ],
+            [
+              9,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-trunk-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": {
+          "stops": [
+            [
+              5,
+              0
+            ],
+            [
+              6,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-motorway-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": {
+          "stops": [
+            [
+              4,
+              0
+            ],
+            [
+              5,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              4,
+              0
+            ],
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-path",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "path"
+        ]
+      ],
+      "paint": {
+        "line-color": "#cba",
+        "line-dasharray": [
+          1.5,
+          0.75
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              4
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-motorway-link",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-link",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-minor",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "minor",
+          "service",
+          "track"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              13.5,
+              0
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-secondary-tertiary",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              8,
+              0.5
+            ],
+            [
+              20,
+              13
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-primary",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8.5,
+              0
+            ],
+            [
+              9,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-trunk",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway-motorway",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "railway-transit",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "class",
+          "transit"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.77)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              20,
+              1
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "railway-transit-hatching",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "class",
+          "transit"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.68)",
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "railway-service",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "has",
+          "service"
+        ]
+      ],
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.77)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              20,
+              1
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "railway-service-hatching",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "has",
+          "service"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.68)",
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "railway",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!has",
+          "service"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "railway-hatching",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!has",
+          "service"
+        ],
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              20,
+              8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-motorway-link-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              19
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-link-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              19
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-secondary-tertiary-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              7,
+              0.6
+            ],
+            [
+              8,
+              1.5
+            ],
+            [
+              20,
+              21
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-trunk-primary-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "hsl(28, 76%, 67%)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              26
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-motorway-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              26
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-minor-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "minor",
+          "service",
+          "track"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {
+          "stops": [
+            [
+              12,
+              0
+            ],
+            [
+              12.5,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              13,
+              1
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              20,
+              24
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-path-casing",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "path"
+        ]
+      ],
+      "paint": {
+        "line-color": "#f8f4f0",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-path",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "path"
+        ]
+      ],
+      "paint": {
+        "line-color": "#cba",
+        "line-dasharray": [
+          1.5,
+          0.75
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              4
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-motorway-link",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-link",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-minor",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "minor",
+          "service",
+          "track"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              13.5,
+              0
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-secondary-tertiary",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              8,
+              0.5
+            ],
+            [
+              20,
+              13
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-trunk-primary",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-motorway",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-railway",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-railway-hatching",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              20,
+              8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "cablecar",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "==",
+        "subclass",
+        "cable_car"
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 70%)",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              19,
+              2.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "cablecar-dash",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "==",
+        "subclass",
+        "cable_car"
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 70%)",
+        "line-dasharray": [
+          2,
+          3
+        ],
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              19,
+              5.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "boundary-land-level-4",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "minzoom": 2,
+      "filter": [
+        "all",
+        [
+          ">=",
+          "admin_level",
+          3
+        ],
+        [
+          "<=",
+          "admin_level",
+          8
+        ],
+        [
+          "!=",
+          "maritime",
+          1
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#9e9cab",
+        "line-dasharray": [
+          3,
+          1,
+          1,
+          1
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              4,
+              0.4
+            ],
+            [
+              5,
+              1
+            ],
+            [
+              12,
+              3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "boundary-land-level-2",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          2
+        ],
+        [
+          "!=",
+          "maritime",
+          1
+        ],
+        [
+          "!=",
+          "disputed",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(248, 7%, 66%)",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.6
+            ],
+            [
+              4,
+              1.4
+            ],
+            [
+              5,
+              2
+            ],
+            [
+              12,
+              8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "boundary-land-disputed",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "filter": [
+        "all",
+        [
+          "!=",
+          "maritime",
+          1
+        ],
+        [
+          "==",
+          "disputed",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(248, 7%, 70%)",
+        "line-dasharray": [
+          1,
+          3
+        ],
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.6
+            ],
+            [
+              4,
+              1.4
+            ],
+            [
+              5,
+              2
+            ],
+            [
+              12,
+              8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "boundary-water",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "in",
+          "admin_level",
+          2,
+          4
+        ],
+        [
+          "==",
+          "maritime",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(154, 189, 214, 1)",
+        "line-opacity": {
+          "stops": [
+            [
+              6,
+              0.6
+            ],
+            [
+              10,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.6
+            ],
+            [
+              4,
+              1.4
+            ],
+            [
+              5,
+              2
+            ],
+            [
+              12,
+              8
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/map-styles/satellite.json
+++ b/src/map-styles/satellite.json
@@ -1,6 +1,12 @@
 {
   "version": 8,
+  "id": "satellite",
+  "name": "Satellite",
   "sources": {
+    "openmaptiles": {
+      "type": "vector",
+      "url": "https://openmaptiles.geo.data.gouv.fr/data/france-vector.json"
+    },
     "satellite": {
       "type": "raster",
       "tiles": [
@@ -9,6 +15,7 @@
       "tileSize": 256
     }
   },
+  "glyphs": "https://openmaptiles.geo.data.gouv.fr/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "fond-satellite",

--- a/src/pages/exploitations/[numeroBio]/[recordId]/ajout-parcelle/dessin.vue
+++ b/src/pages/exploitations/[numeroBio]/[recordId]/ajout-parcelle/dessin.vue
@@ -22,13 +22,13 @@ meta:
     <div class="fr-grid-row fr-grid-row--gutters">
       <div class="fr-col-9">
         <MapContainer v-if="recordStore.isSetup" :options="{ interactive: true }" class="map" :bounds="recordStore.bounds" ref="map" >
-          <LayerSelector v-model:fond="fond" v-model:classification="showClassification" v-model:cadastre="showCadastre" v-model:ilots="showIlots" />
-          <GeojsonLayer v-if="fond === 'plan'" :style="baseStyle" name="base" :before="showCadastre ? 'cadastre' : showClassification ? 'surroundings' : 'parcellaire-operateur'" />
-          <GeojsonLayer v-if="fond === 'satellite'" :style="satelliteStyle" name="satellite" :before="showCadastre ? 'cadastre' : showClassification ? 'surroundings' : 'parcellaire-operateur'" />
-          <GeojsonLayer v-if="showCadastre" :style="cadastreStyle" name="cadastre" before="parcellaire-operateur" />
-          <GeojsonLayer v-if="showClassification" :style="surroundingsStyle" name="surroundings" before="parcellaire-operateur" />
+          <LayerSelector v-model:fond="mapPrefs.background" v-model:classification="mapPrefs.rpg" v-model:cadastre="mapPrefs.cadastre" />
+          <GeojsonLayer v-if="mapPrefs.background === 'plan'" :style="planStyle" name="plan" />
+          <GeojsonLayer v-if="mapPrefs.background === 'satellite'" :style="satelliteStyle" name="satellite" />
+          <GeojsonLayer v-if="mapPrefs.cadastre" :style="cadastreStyle" name="cadastre" before="parcellaire-operateur" />
+          <GeojsonLayer v-if="mapPrefs.rpg" :style="surroundingsStyle" name="surroundings" before="parcellaire-operateur" />
 
-          <FeaturesLayer :show-numeros-ilots="showIlots" />
+          <FeaturesLayer />
         </MapContainer>
       </div>
       <div class="fr-col-3">
@@ -82,28 +82,31 @@ meta:
 
 <script setup>
 import { computed, markRaw, onMounted, ref, toRaw, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import intersect from "@turf/intersect"
 import { TerraDraw, TerraDrawMapLibreGLAdapter, TerraDrawPolygonMode, TerraDrawSelectMode } from "terra-draw"
+import { useFeaturesStore, useOperatorStore, usePermissions, usePreferences, useRecordStore } from "@/stores/index.js"
+import { submitNewParcelle } from "@/cartobio-api.js"
+import { statsPush } from "@/stats.js"
+import { useRouter } from "vue-router"
+import { featureName } from "@/components/Features/index.js"
 
-import baseStyle from "@/map-styles/base.json"
+
+import planStyle from "@/map-styles/plan.json"
 import MapContainer from "@/components/Map/MapContainer.vue"
 import GeojsonLayer from "@/components/Map/GeojsonLayer.vue"
-import { useFeaturesStore, useOperatorStore, usePermissions, useRecordStore } from "@/stores/index.js"
 import ParcellaireState from "@/components/Certification/State.vue"
 import CommuneSelect from "@/components/Forms/CommuneSelect.vue"
 import CertificationBodyEditForm from "@/components/Features/SingleItemCertificationBodyForm.vue"
 import OperatorEditForm from "@/components/Features/SingleItemOperatorForm.vue"
-import { submitNewParcelle } from "@/cartobio-api.js"
-import { statsPush } from "@/stats.js"
-import { useRouter } from "vue-router"
+import FeaturesLayer from "@/components/Map/FeaturesLayer.vue"
+import LayerSelector from "@/components/Map/LayerSelector.vue"
 import Modal from "@/components/Modal.vue"
 import toast from "@/components/toast.js"
+
 import cadastreStyle from "@/map-styles/cadastre.json"
 import surroundingsStyle from "@/map-styles/surroundings.json"
-import LayerSelector from "@/components/Map/LayerSelector.vue"
 import satelliteStyle from "@/map-styles/satellite.json"
-import { featureName } from "@/components/Features/index.js"
-import FeaturesLayer from "@/components/Map/FeaturesLayer.vue"
 
 const props = defineProps({
   numeroBio: {
@@ -116,13 +119,12 @@ const recordStore = useRecordStore()
 const operatorStore = useOperatorStore()
 const featuresStore = useFeaturesStore()
 const permissions = usePermissions()
+const preferences = usePreferences()
 const router = useRouter()
 
 const map = ref(null) // MapContainer instance
-const fond = ref('satellite')
-const showClassification = ref(false)
-const showCadastre = ref(false)
-const showIlots = ref(true)
+const { map: mapPrefs } = storeToRefs(preferences)
+
 let draw // TerraDraw instance
 
 /**

--- a/src/pages/exploitations/[numeroBio]/[recordId]/ajout-parcelle/index.vue
+++ b/src/pages/exploitations/[numeroBio]/[recordId]/ajout-parcelle/index.vue
@@ -21,14 +21,14 @@
 
       <div class="fr-col-6">
         <MapContainer v-if="recordStore.isSetup" :options="{ interactive: true }" class="map" :bounds="mapBounds">
-          <LayerSelector v-model:fond="fond" v-model:classification="showClassification" v-model:cadastre="showCadastre" v-model:ilots="showIlots" />
-          <GeojsonLayer v-if="fond === 'plan'" :style="baseStyle" name="base" :before="showCadastre ? 'cadastre' : showClassification ? 'surroundings' : 'parcellaire-operateur'" />
-          <GeojsonLayer v-if="fond === 'satellite'" :style="satelliteStyle" name="satellite" :before="showCadastre ? 'cadastre' : showClassification ? 'surroundings' : 'parcellaire-operateur'" />
-          <GeojsonLayer v-if="showCadastre" :style="cadastreStyle" name="cadastre" before="parcellaire-operateur" />
-          <GeojsonLayer v-if="showClassification" :style="surroundingsStyle" name="surroundings" before="parcellaire-operateur" />
+          <LayerSelector v-model:fond="mapPrefs.background" v-model:classification="mapPrefs.rpg" v-model:cadastre="mapPrefs.cadastre" />
+          <GeojsonLayer v-if="mapPrefs.background === 'plan'" :style="planStyle" name="plan" />
+          <GeojsonLayer v-if="mapPrefs.background === 'satellite'" :style="satelliteStyle" name="satellite" />
+          <GeojsonLayer v-if="mapPrefs.cadastre" :style="cadastreStyle" name="cadastre" before="parcellaire-operateur" />
+          <GeojsonLayer v-if="mapPrefs.rpg" :style="surroundingsStyle" name="surroundings" before="parcellaire-operateur" />
           <GeojsonLayer v-if="pendingChangesCollection" :data="pendingChangesCollection" name="pending-changes" :fill="{ 'fill-color': '#FDE2B5', 'fill-outline-color': '#000091', 'fill-opacity': 0.8 }" />
 
-          <FeaturesLayer :show-numeros-ilots="showIlots" />
+          <FeaturesLayer />
         </MapContainer>
         <SetupOverlay v-else>
           Parcellaire inconnu
@@ -39,8 +39,10 @@
 </template>
 
 <script setup>
-import { computed, ref, shallowRef } from 'vue'
+import { computed, shallowRef } from 'vue'
+import { storeToRefs } from 'pinia'
 import { bounds } from '@/components/Features/index.js'
+import { usePreferences, useRecordStore } from '@/stores/index.js'
 
 import MapContainer from '@/components/Map/MapContainer.vue'
 import GeojsonLayer from '@/components/Map/GeojsonLayer.vue'
@@ -48,10 +50,9 @@ import SetupOverlay from '@/components/Map/SetupOverlay.vue'
 import OperatorSummary from '@/components/Operator/Summary.vue'
 import FeatureAddFlow from '@/components/Features/AddFlow.vue'
 
-import baseStyle from '@/map-styles/base.json'
+import planStyle from '@/map-styles/plan.json'
 import cadastreStyle from '@/map-styles/cadastre.json'
 
-import { useOperatorStore, useRecordStore } from '@/stores/index.js'
 import satelliteStyle from "@/map-styles/satellite.json"
 import surroundingsStyle from "@/map-styles/surroundings.json"
 import LayerSelector from "@/components/Map/LayerSelector.vue"
@@ -65,12 +66,9 @@ const props = defineProps({
 })
 
 const recordStore = useRecordStore()
-const operatorStore = useOperatorStore()
+const preferences = usePreferences()
 
-const fond = ref('plan')
-const showClassification = ref(false)
-const showCadastre = ref(true)
-const showIlots = ref(true)
+const { map: mapPrefs } = storeToRefs(preferences)
 
 const pendingChangesCollection = shallowRef(null)
 const mapBounds = computed(() => {

--- a/src/pages/exploitations/[numeroBio]/[recordId]/index.vue
+++ b/src/pages/exploitations/[numeroBio]/[recordId]/index.vue
@@ -36,13 +36,13 @@ meta:
         <div class="sticky-map" :class="{ 'sticky-map--full-size': isMapFullSize }">
           <div :class="{ 'full-size-map fr-card fr-card--shadow fr-p-2w': isMapFullSize }">
             <MapContainer class="map" :class="{ 'map--full-size': isMapFullSize }" :mode="isMapFullSize ? 'fullsize' : 'compact'" :bounds="recordStore.bounds" :show-attribution="true" ref="mapRef">
-              <LayerSelector v-model:fond="fond" v-model:classification="showClassification" v-model:cadastre="showCadastre" v-model:ilots="showIlots" />
-              <GeojsonLayer v-if="fond === 'plan'" :style="baseStyle" name="base" :before="showCadastre ? 'cadastre' : showClassification ? 'surroundings' : 'parcellaire-operateur'" />
-              <GeojsonLayer v-if="fond === 'satellite'" :style="satelliteStyle" name="satellite" :before="showCadastre ? 'cadastre' : showClassification ? 'surroundings' : 'parcellaire-operateur'" />
-              <GeojsonLayer v-if="showCadastre" :style="cadastreStyle" name="cadastre" before="parcellaire-operateur" />
-              <GeojsonLayer v-if="showClassification" :style="surroundingsStyle" name="surroundings" before="parcellaire-operateur" />
+              <LayerSelector v-model:fond="mapPrefs.background" v-model:classification="mapPrefs.rpg" v-model:cadastre="mapPrefs.cadastre" />
+              <GeojsonLayer v-if="mapPrefs.background === 'plan'" :style="planStyle" name="plan"  />
+              <GeojsonLayer v-if="mapPrefs.background === 'satellite'" :style="satelliteStyle" name="satellite" />
+              <GeojsonLayer v-if="mapPrefs.cadastre" :style="cadastreStyle" name="cadastre" before="parcellaire-operateur" />
+              <GeojsonLayer v-if="mapPrefs.rpg" :style="surroundingsStyle" name="surroundings" before="parcellaire-operateur" />
 
-              <FeaturesLayer :show-numeros-ilots="showIlots" interactive />
+              <FeaturesLayer interactive />
               <CustomControls @center="focusOnOriginalBbox" v-model:large="isMapFullSize" />
             </MapContainer>
           </div>
@@ -54,18 +54,19 @@ meta:
 
 <script setup>
 import { computed, markRaw, ref, shallowRef } from 'vue'
+import { storeToRefs } from 'pinia'
 import { bounds } from '@/components/Features/index.js'
 
 import FeaturesTable from '@/components/Features/Table.vue'
 import MapContainer from '@/components/Map/MapContainer.vue'
 import GeojsonLayer from '@/components/Map/GeojsonLayer.vue'
-import baseStyle from '@/map-styles/base.json'
+import planStyle from '@/map-styles/plan.json'
 import SingleItemOperatorForm from '@/components/Features/SingleItemOperatorForm.vue'
 import SingleItemCertificationBodyForm from "@/components/Features/SingleItemCertificationBodyForm.vue"
 import OperatorSummary from '@/components/Operator/Summary.vue'
 import CultureTypeModal from '@/components/Operator/CultureTypeModal.vue'
 
-import { useFeaturesStore, useOperatorStore, usePermissions, useRecordStore } from "@/stores/index.js"
+import { useFeaturesStore, useOperatorStore, usePermissions, usePreferences, useRecordStore } from "@/stores/index.js"
 import { applyValidationRules, AUDITOR_RULES, OPERATOR_RULES } from '@/referentiels/ab.js'
 import surroundingsStyle from "@/map-styles/surroundings.json";
 import cadastreStyle from "@/map-styles/cadastre.json";
@@ -82,14 +83,13 @@ const recordStore = useRecordStore()
 const operatorStore = useOperatorStore()
 const featureStore = useFeaturesStore()
 const permissions = usePermissions()
+const preferences = usePreferences()
 const { record } = recordStore
 const { operator } = operatorStore
 
 const mapRef = shallowRef(null)
-const fond = ref('plan')
-const showClassification = ref(false)
-const showCadastre = ref(false)
-const showIlots = ref(true)
+
+const { map: mapPrefs } = storeToRefs(preferences)
 const isMapFullSize = ref(false)
 
 const validationRules = computed(() => ({ rules: permissions.isOc ? AUDITOR_RULES : OPERATOR_RULES }))

--- a/src/pages/exploitations/[numeroBio]/[recordId]/modifier/[featureId].vue
+++ b/src/pages/exploitations/[numeroBio]/[recordId]/modifier/[featureId].vue
@@ -23,13 +23,13 @@ meta:
           <p>{{ loadingError }}</p>
         </div>
         <MapContainer v-if="recordStore.isSetup" :options="{ interactive: true }" class="map" :bounds="mapBounds" ref="map" >
-          <LayerSelector v-model:fond="fond" v-model:classification="showClassification" v-model:cadastre="showCadastre" v-model:ilots="showIlots" />
-          <GeojsonLayer v-if="fond === 'plan'" :style="baseStyle" name="base" :before="showCadastre ? 'cadastre' : showClassification ? 'surroundings' : 'parcellaire-operateur'" />
-          <GeojsonLayer v-if="fond === 'satellite'" :style="satelliteStyle" name="satellite" :before="showCadastre ? 'cadastre' : showClassification ? 'surroundings' : 'parcellaire-operateur'" />
-          <GeojsonLayer v-if="showCadastre" :style="cadastreStyle" name="cadastre" before="parcellaire-operateur" />
-          <GeojsonLayer v-if="showClassification" :style="surroundingsStyle" name="surroundings" before="parcellaire-operateur" />
+          <LayerSelector v-model:fond="mapPrefs.background" v-model:classification="mapPrefs.rpg" v-model:cadastre="mapPrefs.cadastre" />
+          <GeojsonLayer v-if="mapPrefs.background === 'plan'" :style="planStyle" name="plan" />
+          <GeojsonLayer v-if="mapPrefs.background === 'satellite'" :style="satelliteStyle" name="satellite" />
+          <GeojsonLayer v-if="mapPrefs.cadastre" :style="cadastreStyle" name="cadastre" before="parcellaire-operateur" />
+          <GeojsonLayer v-if="mapPrefs.rpg" :style="surroundingsStyle" name="surroundings" before="parcellaire-operateur" />
 
-          <FeaturesLayer :data="otherCollection" :show-numeros-ilots="showIlots" />
+          <FeaturesLayer :data="otherCollection" />
         </MapContainer>
       </div>
       <div class="fr-col-3">
@@ -83,13 +83,13 @@ meta:
 </template>
 
 <script setup>
-
-import baseStyle from "@/map-styles/base.json"
+import planStyle from "@/map-styles/plan.json"
 import ParcellaireState from "@/components/Certification/State.vue"
 import MapContainer from "@/components/Map/MapContainer.vue"
 import GeojsonLayer from "@/components/Map/GeojsonLayer.vue"
-import { useFeaturesStore, useOperatorStore, useRecordStore } from "@/stores/index.js"
+import { useFeaturesStore, useOperatorStore, usePreferences, useRecordStore } from "@/stores/index.js"
 import { computed, onMounted, ref, watch } from "vue"
+import { storeToRefs } from 'pinia'
 import { TerraDraw, TerraDrawMapLibreGLAdapter, TerraDrawPolygonMode, TerraDrawSelectMode } from "terra-draw"
 import intersect from "@turf/intersect"
 import { bounds, featureName, inHa, surface } from "@/components/Features/index.js"
@@ -116,10 +116,13 @@ const props = defineProps({
   },
 })
 
-const operatorStore = useOperatorStore()
-const recordStore = useRecordStore()
 const featuresStore = useFeaturesStore()
+const operatorStore = useOperatorStore()
+const preferences = usePreferences()
+const recordStore = useRecordStore()
 const router = useRouter()
+
+const { map: mapPrefs } = storeToRefs(preferences)
 
 const otherCollection = computed(() => loadingError.value ? featuresStore.collection : featureCollection(
     featuresStore.collection.features.filter(f => f.id !== String(props.featureId)))
@@ -129,10 +132,6 @@ const modifiedFeature = ref(null)
 const mapBounds = computed(() => bounds(featuresStore.getFeatureById(String(props.featureId))))
 
 const map = ref(null) // MapContainer instance
-const fond = ref('satellite')
-const showClassification = ref(false)
-const showCadastre = ref(false)
-const showIlots = ref(false)
 
 let draw // TerraDraw instance
 const loadingError = ref('')

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,5 +1,6 @@
 export { useFeaturesStore } from './features.js'
 export { usePermissions } from './permissions.js'
+export { usePreferences } from './preferences.js'
 export { useRecordStore } from './record.js'
 export { useUserStore } from './user.js'
 export { useOperatorStore } from './operator.js'

--- a/src/stores/preferences.js
+++ b/src/stores/preferences.js
@@ -1,0 +1,30 @@
+import { defineStore } from 'pinia'
+import { useStorageAsync } from '@vueuse/core'
+
+const defaultMapPreferences = () => ({
+  background: 'plan',
+  cadastre: false,
+  rpg: false
+})
+
+export const usePreferences = defineStore('preferences', () => {
+  const map = useStorageAsync(
+    'cartobio/preferences/map',
+    defaultMapPreferences(),
+    localStorage,
+    {
+      mergeDefaults: true,
+    }
+  )
+
+  function $reset () {
+    map.value = defaultMapPreferences()
+  }
+
+  return {
+    // domains
+    map,
+    // utility
+    $reset
+  }
+})

--- a/src/stores/preferences.test.js
+++ b/src/stores/preferences.test.js
@@ -1,0 +1,37 @@
+import { afterEach, describe, it, expect, vi } from "vitest"
+import { usePreferences } from "./index.js"
+import { createTestingPinia } from "@pinia/testing"
+
+const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+const preferences = usePreferences(pinia)
+
+describe('preferences/map', () => {
+  afterEach(() => preferences.$reset())
+
+  it('should provide sensible defaults', () => {
+    expect(preferences.map).toEqual({
+      background: 'plan',
+      cadastre: false,
+      rpg: false
+    })
+  })
+
+  // for some reasons, vueuse does not seem to detect localStorage
+  it.skip('should store updated values in localStorage', () => {
+    preferences.map.background = 'satellite'
+
+    expect(localStorage.setItem).toHaveBeenCalledWith('cartobio/preferences/map', {
+      background: 'satellite',
+      cadastre: false,
+      rpg: false
+    })
+  })
+
+  it('should reset the values', () => {
+    preferences.map.background = 'satellite'
+
+    preferences.$reset()
+
+    expect(preferences).toHaveProperty('map.background', 'plan')
+  })
+})

--- a/tests-setup.js
+++ b/tests-setup.js
@@ -73,6 +73,11 @@ vi.stubGlobal('matchMedia', vi.fn(() => ({
   matches: vi.fn().mockReturnValue(true)
 })))
 
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn(),
+  setItem: vi.fn()
+})
+
 vi.spyOn(global, 'navigator', 'get').mockImplementation(() => ({
   clipboard: {
     writeText: vi.fn()


### PR DESCRIPTION
- renomme les intitulés
- introduit un Store de préférences synchronisé avec le localStorage
- gère mieux l'ordre des calques (les intitulés ne sont pas cachés sous des `fill`)
- fermeture sur un clic en dehors du menu