### PR TITLE
Les stores gèrent la sauvegarde des données

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev-sw": "vite build & (sleep 1 && vite preview --port 3000)",
+    "dev-sw": "vite build --watch & (sleep 1 && vite preview --port 3000)",
     "build": "npm run build:app",
     "build:app": "vite build",
     "build:widget": "vite build --config vite.widget.config.js --mode lib",

--- a/src/cartobio-api.js
+++ b/src/cartobio-api.js
@@ -11,7 +11,7 @@ const { VUE_APP_API_ENDPOINT: baseURL } = import.meta.env
  * @typedef {import('@agencebio/cartobio-types').CartoBioFeatureCollection} CartoBioFeatureCollection
  */
 
-const apiClient = axios.create({ baseURL, timeout: 10000 })
+export const apiClient = axios.create({ baseURL, timeout: 10000 })
 
 /**
  *
@@ -53,28 +53,6 @@ export async function pacageLookup (pacage) {
   return data
 }
 
-
-/**
- * @param {string} numeroBio
- * @returns {Promise<import('@agencebio/cartobio-types').AgenceBioNormalizedOperator>}
- */
-export async function getOperator (numeroBio) {
-  const { data } = await apiClient.get(`/v2/operator/${numeroBio}`)
-
-  return data
-}
-
-/**
- * @param {string} numeroBio
- * @return {Promise<import('@agencebio/cartobio-types').NormalizedRecordSummary[]>}
- */
-export async function getOperatorRecords (numeroBio) {
-  const { data } = await apiClient.get(`/v2/operator/${numeroBio}/records`)
-
-  return data
-}
-
-
 /**
  * Creates a new operator Record
  *
@@ -82,61 +60,6 @@ export async function getOperatorRecords (numeroBio) {
  */
 export async function createOperatorRecord (numeroBio, payload) {
   const { data } = await apiClient.post(`/v2/operator/${numeroBio}/records`, payload)
-
-  return data
-}
-
-/**
- * @param {UUID} recordId
- * @return {Promise<NormalizedRecord>}
- */
-export async function getRecord (recordId) {
-  const { data } = await apiClient.get(`/v2/audits/${recordId}`)
-
-  return data
-}
-
-/**
- * Delete a single feature
- *
- * @return {Promise<NormalizedRecord>}
- */
-export async function deleteSingleFeature ({ recordId }, { id, reason }) {
-  const { data } = await apiClient.delete(`/v2/audits/${recordId}/parcelles/${id}`, {data: { reason }})
-
-  return data
-}
-
-/**
- * Creates or updates a record based on geographical informations
- *
- * @returns {Promise<NormalizedRecord>}
- */
-export async function updateFeatureCollectionProperties ({ recordId }, featureCollection) {
-  const { data } = await apiClient.patch(`/v2/audits/${recordId}/parcelles`, featureCollection)
-
-  return data
-}
-
-/**
- * Update/replace properties of a single feature
- *
- * @returns {Promise<NormalizedRecord>}
- */
-export async function updateSingleFeature ({ recordId }, { id, properties, geometry }) {
-  const { data } = await apiClient.put(`/v2/audits/${recordId}/parcelles/${id}`, { properties, geometry })
-
-  return data
-}
-
-/**
- *
- * @param {string} recordId
- * @param {Object} patch
- * @returns {Promise<NormalizedRecord>}
- */
-export async function updateAuditState (recordId, patch) {
-  const { data } = await apiClient.patch(`/v2/audits/${recordId}`, patch)
 
   return data
 }

--- a/src/components/Features/SingleItemCertificationBodyForm.test.js
+++ b/src/components/Features/SingleItemCertificationBodyForm.test.js
@@ -101,6 +101,7 @@ describe("SingleItemCertificationBodyForm", () => {
     await form.find('#downgraded_state').setValue(CERTIFICATION_BODY_DECISION.ACCEPTED)
 
     // click and assess server update
+    axios.__createMock.put.mockResolvedValueOnce({ data: record })
     await form.find('.fr-modal__footer button.fr-btn').trigger('click')
 
     expect(wrapper.findComponent(EditForm).exists()).toEqual(false)

--- a/src/components/Features/Table.test.js
+++ b/src/components/Features/Table.test.js
@@ -113,7 +113,7 @@ describe("Features Table", () => {
     await table.find('tr#parcelle-2 td').trigger('click')
     await flushPromises()
 
-    axios.__createMock.put.mockResolvedValueOnce(record)
+    axios.__createMock.put.mockResolvedValueOnce({ data: record })
 
     // this throws if the modal form does not exist
     // it catches the Component reference even if it has been Teleport-ed in the <body>
@@ -138,7 +138,7 @@ describe("Features Table", () => {
     await wrapper.find('#parcelle-3 .menu-container .fr-icon-delete-line').trigger('click')
 
     // we trigger the deletion
-    axios.__createMock.delete.mockResolvedValueOnce(record)
+    axios.__createMock.delete.mockResolvedValueOnce({ data: record })
 
     const modal = wrapper.getComponent(DeleteFeatureModal)
     expect(modal.text()).toContain("parcelle 3")
@@ -182,7 +182,7 @@ describe("Features Table", () => {
     expect(modal.exists()).toEqual(false)
 
     // now, we change a field and we should not be able to close it
-    axios.__createMock.put.mockResolvedValueOnce(record)
+    axios.__createMock.put.mockResolvedValueOnce({ data: record })
 
     table.find('tr.parcelle td').trigger('click')
     await flushPromises()

--- a/src/components/record/CertificationSection.vue
+++ b/src/components/record/CertificationSection.vue
@@ -1,14 +1,12 @@
 <script setup>
 import { computed, ref } from 'vue'
 import { CERTIFICATION_STATE, isCertificationImmutable } from '@/referentiels/ab.js'
-import { updateAuditState } from '@/cartobio-api.js'
 import { useFeaturesSetsStore } from "@/stores/features-sets.js"
 import { useOperatorStore } from "@/stores/operator.js"
 import { usePermissions } from "@/stores/permissions.js"
 import { useRecordStore } from "@/stores/record.js"
 import CertificationModal from "@/components/record/modals/CertificationModal.vue"
 import SaveAuditModal from "@/components/record/modals/SaveAuditModal.vue"
-import toast from "@/components/toast.js"
 
 const recordStore = useRecordStore()
 const operatorStore = useOperatorStore()
@@ -23,64 +21,27 @@ const showCertificationModal = ref(false)
 
 const canEndAudit = computed(() => permissions.isOc && recordStore.hasFeatures && !featuresSets.hasRequiredSets)
 
-async function handleSaveAudit ({ record_id: recordId, patch }) {
-  let newRecord
-  try {
-    newRecord = await updateAuditState(recordId, {
-          ...patch,
-          certification_state: CERTIFICATION_STATE.AUDITED
-        }
-    )
-  } catch (e) {
-    if (e.response?.status === 400) {
-      toast.error(e.response.data.error)
-      return
-    }
+async function handleSaveAudit ({ patch }) {
+  await recordStore.updateInfo({
+    ...patch,
+    certification_state: CERTIFICATION_STATE.AUDITED
+  })
 
-    throw e
-  }
-
-  recordStore.update(newRecord)
   showSaveAuditModal.value = false
 }
 
 async function handleSendAudit () {
-  let newRecord
-  try {
-    newRecord = await updateAuditState(
-        record.record_id,
-        { certification_state: CERTIFICATION_STATE.PENDING_CERTIFICATION }
-    )
-  } catch (e) {
-    if (e.response?.status === 400) {
-      toast.error(e.response.data.error)
-      return
-    }
-
-    throw e
-  }
-
-  recordStore.update(newRecord)
+  await recordStore.updateInfo({
+    certification_state: CERTIFICATION_STATE.PENDING_CERTIFICATION
+  })
 }
 
-async function handleCertify ({ record_id: recordId, patch }) {
-  let newRecord
-  try {
-    newRecord = await updateAuditState(recordId, {
-          ...patch,
-          certification_state: CERTIFICATION_STATE.CERTIFIED
-        }
-    )
-  } catch (e) {
-    if (e.response?.status === 400) {
-      toast.error(e.response.data.error)
-      return
-    }
+async function handleCertify ({ patch }) {
+  await recordStore.updateInfo({
+    ...patch,
+    certification_state: CERTIFICATION_STATE.CERTIFIED
+  })
 
-    throw e
-  }
-
-  recordStore.update(newRecord)
   showCertificationModal.value = false
 }
 </script>

--- a/src/components/record/Header.vue
+++ b/src/components/record/Header.vue
@@ -66,8 +66,6 @@
     <AsyncFeaturesExportModal v-if="exportModal" :operator="operator" :collection="collection" :record="record" @close="exportModal = false" />
     <DeleteParcellaireModal :record="record" v-if="deleteModal" @close="deleteModal = false" />
     <EditVersionModal
-        :model-value="record"
-        @update:model-value="recordStore.update($event)"
         v-if="showEditVersionModal"
         @close="showEditVersionModal = false"
     />

--- a/src/components/record/modals/SaveAuditModal.vue
+++ b/src/components/record/modals/SaveAuditModal.vue
@@ -4,7 +4,7 @@
 
     <h2 class="fr-text--lead">{{ operator.nom }}</h2>
 
-    <form id="sendoff-form" @submit.prevent="emit('submit', { record_id: record.record_id, patch })">
+    <form id="sendoff-form" @submit.prevent="emit('submit', { patch })">
       <div class="fr-input-group">
         <label class="fr-label" for="audit_notes">
           Notes finales de l'audit

--- a/src/components/versions/EditVersionModal.vue
+++ b/src/components/versions/EditVersionModal.vue
@@ -1,32 +1,28 @@
 <script setup>
 import Modal from "@/components/Modal.vue"
 import { reactive } from "vue"
-import { updateAuditState } from "@/cartobio-api.js"
 import toast from "@/components/toast.js"
+import { useRecordStore } from "@/stores/record.js"
 
-const props = defineProps({
-  modelValue: {
-    type: Object,
-    required: true
-  }
-})
-const emit = defineEmits(['close', 'update:modelValue'])
+const emit = defineEmits(['close'])
 
+const recordStore = useRecordStore()
+const { record } = recordStore
 
 const patch = reactive({
-  version_name: props.modelValue.version_name,
-  audit_date: props.modelValue.audit_date,
-  certification_date_fin: props.modelValue.certification_date_fin
+  version_name: record.version_name,
+  audit_date: record.audit_date,
+  certification_date_fin: record.certification_date_fin
 })
 
 async function save() {
-  const record = await updateAuditState(props.modelValue.record_id, {
+  await recordStore.updateInfo({
     version_name: patch.version_name,
-  ...(patch.audit_date && { audit_date: patch.audit_date }),
-  ...(patch.certification_date_fin && { certification_date_fin: patch.certification_date_fin })
+    ...(patch.audit_date && { audit_date: patch.audit_date }),
+    ...(patch.certification_date_fin && { certification_date_fin: patch.certification_date_fin })
   })
+
   toast.success('La version a bien été modifiée')
-  emit('update:modelValue', record)
   emit('close')
 }
 
@@ -48,12 +44,12 @@ async function save() {
         <input type="date" id="audit_date" class="fr-input" v-model="patch.audit_date" />
       </div>
 
-      <div v-if="modelValue.certification_state === 'CERTIFIED'" class="fr-input-group">
-        <label for="certification_date_fin" class="fr-input-group__label">Date de début de validité du certificat</label>
-        <input type="date" id="certification_date_fin" class="fr-input" :value="modelValue.certification_date_debut" disabled />
+      <div v-if="record.certification_state === 'CERTIFIED'" class="fr-input-group">
+        <label for="certification_date_debut" class="fr-input-group__label">Date de début de validité du certificat</label>
+        <input type="date" id="certification_date_debut" class="fr-input" :value="record.certification_date_debut" disabled />
       </div>
 
-      <div v-if="modelValue.certification_state === 'CERTIFIED'" class="fr-input-group">
+      <div v-if="record.certification_state === 'CERTIFIED'" class="fr-input-group">
         <label for="certification_date_fin" class="fr-input-group__label">Date de fin de validité du certificat</label>
         <input type="date" id="certification_date_fin" class="fr-input" v-model="patch.certification_date_fin" />
       </div>

--- a/src/pages/exploitations/[numeroBio]/[recordId]/modifier/[featureId].vue
+++ b/src/pages/exploitations/[numeroBio]/[recordId]/modifier/[featureId].vue
@@ -101,7 +101,6 @@ import { usePermissions} from "@/stores/permissions.js"
 import { TerraDraw, TerraDrawMapLibreGLAdapter, TerraDrawPolygonMode, TerraDrawSelectMode } from "terra-draw"
 import intersect from "@turf/intersect"
 import { bounds, featureName, inHa, legalProjectionSurface } from "@/components/Features/index.js"
-import { updateSingleFeature } from "@/cartobio-api.js"
 import { statsPush } from "@/stats.js"
 import Modal from "@/components/Modal.vue"
 import toast from "@/components/toast.js"
@@ -241,17 +240,13 @@ watch(modifiedFeature, () => {
 }, { deep: true })
 
 async function saveFeature () {
-  const record = await updateSingleFeature({ recordId: recordStore.record.record_id }, modifiedFeature.value)
-  const id = modifiedFeature.value.id
-
-  recordStore.update(record)
-  featuresStore.setAll(record.parcelles.features)
+  await featuresStore.updateSingleFeature(modifiedFeature.value)
 
   statsPush(['trackEvent', 'Parcelles', 'Modification (tracé)'])
   await router.push(`/exploitations/${props.numeroBio}/${record.record_id}`)
 
   toast.success(`Parcelle « ${featureName(modifiedFeature.value)} » modifiée.`, 'Voir la parcelle', () => {
-    featuresStore.select(id)
+    featuresStore.select(modifiedFeature.value.id)
   })
 }
 </script>

--- a/src/pages/exploitations/[numeroBio]/index.vue
+++ b/src/pages/exploitations/[numeroBio]/index.vue
@@ -51,7 +51,7 @@ meta:
           <col class="audit-date"/>
           <col class="surface"/>
           <col class="parcelles"/>
-          <col class="statut"/>
+          <col class="offline"/>
           <col class="actions"/>
         </colgroup>
         <thead>
@@ -84,6 +84,7 @@ meta:
             <col class="surface"/>
             <col class="parcelles"/>
             <col class="statut"/>
+            <col class="offline"/>
             <col class="actions"/>
           </colgroup>
           <thead>
@@ -118,7 +119,7 @@ meta:
             <td>
               <ActionDropdown with-icons>
                 <li>
-                  <button type="button" @click.stop.prevent="editVersionModal = record.record_id" class="fr-btn fr-btn--tertiary-no-outline fr-icon-edit-line fr-text--sm">
+                  <button type="button" @click.stop.prevent="editVersion(record.record_id)" class="fr-btn fr-btn--tertiary-no-outline fr-icon-edit-line fr-text--sm">
                     Modifier les informations
                   </button>
                 </li>
@@ -145,12 +146,6 @@ meta:
     <Teleport to="body">
       <NewVersionModal @close="newVersionModal = false" v-if="newVersionModal" />
       <EditVersionModal
-          :model-value="operatorStore.records.find(record => record.record_id === editVersionModal)"
-          @update:model-value="Object.assign(operatorStore.records.find(record => record.record_id === $event.record_id), {
-          version_name: $event.version_name,
-          audit_date: $event.audit_date,
-          certification_date_fin: $event.certification_date_fin
-        })"
           v-if="editVersionModal"
           @close="editVersionModal = null"
       />
@@ -179,11 +174,16 @@ import { sources } from '@/referentiels/imports.js'
 import ActionByOperator from "@/components/OperatorSetup/Actions/ByOperator.vue"
 import { inHa } from "@/components/Features/index.js"
 import { dateFormat } from "@/components/dates.js"
-import { createOperatorRecord, getRecord } from "@/cartobio-api.js"
 import toast from "@/components/toast.js"
+import { useRecordStore } from "@/stores/record.js"
 
 const operatorStore = useOperatorStore()
+const recordStore = useRecordStore()
 const permissions = usePermissions()
+
+const newVersionModal = ref(false)
+const deleteRecordModal = ref(null)
+const editVersionModal = ref(null)
 
 const operatorSetupActions = [
   ...(permissions.isOc ? [{ id: 'operator', selector: markRaw(ActionByOperator) }] : []),
@@ -213,32 +213,16 @@ useHead({
   title: `Parcellaires ${operatorStore.operator.nom} (${operatorStore.operator.numeroBio})`
 })
 
-async function duplicateVersion(record_id) {
-  const recordSummary = operatorStore.records.find(record => record.record_id === record_id)
-  const record = await getRecord(record_id)
-  const newRecord = await createOperatorRecord(operatorStore.operator.numeroBio, {
-    versionName: `Copie de ${record.version_name}`,
-    geojson: record.parcelles,
-    metadata: {
-      provenance: window.location.host,
-      source: 'Copie de version existante',
-      copy_of: record.record_id
-    }
-  })
-  operatorStore.records?.unshift({
-    ...newRecord,
-    parcelles: recordSummary.parcelles,
-    surface: recordSummary.surface,
-  })
+async function editVersion(recordId) {
+  await recordStore.ready(recordId)
+  editVersionModal.value = recordId
+}
 
+async function duplicateVersion(recordId) {
+  await recordStore.duplicate(recordId)
 
   toast.success('La version a été dupliquée')
 }
-
-const newVersionModal = ref(false)
-const deleteRecordModal = ref(null)
-const editVersionModal = ref(null)
-
 </script>
 
 <style scoped>
@@ -279,12 +263,20 @@ col.version-name {
   width: 15rem;
 }
 
+col.audit-date {
+  width: 10rem;
+}
+
 col.surface {
   width: 10rem;
 }
 
-col.audit-date {
-  width: 10rem;
+col.statut {
+  width: 15rem;
+}
+
+col.offline {
+  width: 5rem;
 }
 
 col.actions {

--- a/src/stores/features.js
+++ b/src/stores/features.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref, watch } from 'vue'
 import { useFeaturesSetsStore } from "@/stores/features-sets.js"
+import { apiClient } from "@/cartobio-api.js"
 
 
 /**
@@ -20,6 +21,7 @@ export const useFeaturesStore = defineStore('features', () => {
   const selectedIds = ref([])
   const activeId = ref(null)
   const hoveredId = ref(null)
+  const recordId = ref(null)
 
   /**
    * @type {reactive<CartoBioFeatureCollection>}
@@ -236,6 +238,35 @@ export const useFeaturesStore = defineStore('features', () => {
   }
 
   /**
+   * Update/replace properties of a single feature
+   * @param {CartoBioFeature} feature
+   * @returns {Promise<void>}
+   */
+  async function updateSingleFeature ({ id, properties, geometry }) {
+    const { data: updatedRecord } = await apiClient.put(`/v2/audits/${recordId.value}/parcelles/${id}`, { properties, geometry })
+    setAll(updatedRecord.parcelles.features)
+  }
+
+  /**
+   * Creates or updates multiple features properties
+   * @param {CartoBioFeatureCollection} featureCollection
+   * @returns {Promise<void>}
+   */
+  async function updateFeatureCollectionProperties (featureCollection) {
+    const { data: updatedRecord } = await apiClient.patch(`/v2/audits/${recordId.value}/parcelles`, featureCollection)
+    setAll(updatedRecord.parcelles.features)
+  }
+
+  /**
+   * Delete a single feature
+   * @return {Promise<void>}
+   */
+  async function deleteSingleFeature ({ id, reason }) {
+    const { data: updatedRecord } = await apiClient.delete(`/v2/audits/${recordId.value}/parcelles/${id}`, {data: { reason }})
+    setAll(updatedRecord.parcelles.features)
+  }
+
+  /**
    * @param {CartoBioFeature[]} features
    */
   function updateMatchingFeatures (features) {
@@ -255,6 +286,7 @@ export const useFeaturesStore = defineStore('features', () => {
   }
 
   return {
+    recordId,
     activeId,
     hoveredId,
     selectedIds,
@@ -280,6 +312,9 @@ export const useFeaturesStore = defineStore('features', () => {
     toggleAllSelected,
     toggleSingleSelected,
     unselect,
+    updateSingleFeature,
+    updateFeatureCollectionProperties,
+    deleteSingleFeature,
     updateMatchingFeatures
   }
 })

--- a/src/stores/operator.js
+++ b/src/stores/operator.js
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia"
 import { computed, ref, watch } from "vue"
 import { CUSTOM_DIMENSION_DEPARTEMENT, deleteCustomDimension, setCustomDimension } from "@/stats.js"
-import { getOperator, getOperatorRecords } from "@/cartobio-api.js"
+import { apiClient } from "@/cartobio-api.js"
 
 /**
  * @typedef {import('@vue/reactivity').Ref} Ref
@@ -48,11 +48,12 @@ export const useOperatorStore = defineStore('operator', () => {
    */
   async function ready (numeroBio) {
     if (String(operator.value.numeroBio) !== numeroBio) {
-      operator.value = await getOperator(numeroBio)
+      const { data: fetchedOperator } = await apiClient.get(`/v2/operator/${numeroBio}`)
+      operator.value = fetchedOperator
       records.value = null
     }
 
-    getOperatorRecords(numeroBio).then((r) => {
+    apiClient.get(`/v2/operator/${numeroBio}/records`).then(({ data: r }) => {
       records.value = r.sort((recordA, recordB) => date(recordB) - date(recordA))
     })
   }


### PR DESCRIPTION
Aucune gestion du hors-ligne pour le moment, mais la gestion de l'enregistrement est entièrement déplacée dans le recordStore, de telle manière à pouvoir gérer de la sauvegarde hors-ligne / en-ligne / du localStorage sans avoir à s'en préoccuper dans l'interface.