### PR TITLE
Retours hors-ligne

### DIFF
--- a/src/cartobio-api.js
+++ b/src/cartobio-api.js
@@ -56,6 +56,8 @@ export async function pacageLookup (pacage) {
 /**
  * Creates a new operator Record
  *
+ * @param {string} numeroBio
+ * @param {Partial<NormalizedRecord>} payload
  * @returns {Promise<NormalizedRecord>}
  */
 export async function createOperatorRecord (numeroBio, payload) {

--- a/src/components/Conflict.vue
+++ b/src/components/Conflict.vue
@@ -18,7 +18,7 @@ const modalRecordId = ref(null)
     <ul class="fr-text--bold">
       <li v-for="conflict in storage.conflicts" :key="conflict">
         <a href="#" @click="modalRecordId = conflict">
-          {{ storage.operators[storage.records[conflict].numerobio].operator.nom }}
+          {{ storage.operators[storage.records[conflict].numerobio].operator.nom }} - {{ storage.records[conflict].version_name }}
         </a>
       </li>
     </ul>

--- a/src/components/OperatorSetup/Flow.vue
+++ b/src/components/OperatorSetup/Flow.vue
@@ -123,7 +123,7 @@ async function handlePreviewConfirmation (importPrevious) {
   const { numeroBio } = props.operator
 
   record.value = await createOperatorRecord(numeroBio, {
-    geojson: featureCollection.value,
+    parcelles: featureCollection.value,
     metadata: metadata.value,
     importPrevious
   })
@@ -135,7 +135,7 @@ async function handleUploadAndSave ({ geojson, metadata, source }) {
   const { numeroBio } = props.operator
 
   record.value = await createOperatorRecord(numeroBio, {
-    geojson,
+    parcelles: geojson,
     metadata: {
       ...metadata,
       provenance: window.location.host,

--- a/src/components/versions/NewVersionModal.vue
+++ b/src/components/versions/NewVersionModal.vue
@@ -16,7 +16,7 @@ useFocus(autofocusedElement, { initialValue: true })
 
 async function createEmptyVersion() {
    recordStore.update(await createOperatorRecord(operatorStore.operator.numeroBio, {
-    geojson: { type: 'FeatureCollection', features: [] },
+    parcelles: { type: 'FeatureCollection', features: [] },
     metadata: {
       provenance: window.location.host,
       source: sources.MANUAL,

--- a/src/stores/record.js
+++ b/src/stores/record.js
@@ -143,8 +143,8 @@ export const useRecordStore = defineStore('record', () => {
     const recordSummary = operatorStore.records.find(record => record.record_id === id)
     const record = await getRecord(id)
     const newRecord = await createOperatorRecord(operatorStore.operator.numeroBio, {
-      versionName: `Copie de ${record.version_name}`,
-      geojson: record.parcelles,
+      version_name: `Copie de ${record.version_name}`,
+      parcelles: record.parcelles,
       metadata: {
         provenance: window.location.host,
         source: 'Copie de version existante',

--- a/src/stores/storage.js
+++ b/src/stores/storage.js
@@ -328,13 +328,20 @@ export const useCartoBioStorage = defineStore('storage', () => {
 
     if (duplicate) {
       const newRecord = await createOperatorRecord(record.numerobio, {
-        versionName: `${record.version_name} (copie hors-ligne)`,
-        geojson: record.parcelles,
+        version_name: `${record.version_name} (copie hors-ligne)`,
+        parcelles: record.parcelles,
+        certification_state: record.certification_state,
+        certification_date_debut: record.certification_date_debut,
+        certification_date_fin: record.certification_date_fin,
         metadata: {
           provenance: window.location.host,
           source: 'Copie lors de la résolution de conflits',
           copy_of: record.record_id
-        }
+        },
+        audit_date: record.audit_date,
+        audit_notes: record.audit_notes,
+        audit_demandes: record.audit_demandes,
+        audit_history: record.audit_history
       })
       await addRecord(newRecord.record_id)
       syncQueues.value[newRecord.record_id] = syncQueues.value[recordId]


### PR DESCRIPTION
Copie toutes les infos lors de la duplication après conflit. Utilise le type NormalizedRecord pour POST les nouveaux records. Dépend de https://github.com/AgenceBio/cartobio-api/pull/198.