### PR TITLE
Couleur de fond au survol des boutons dans les tableaux

### DIFF
--- a/src/components/records/Table/FeatureGroup.vue
+++ b/src/components/records/Table/FeatureGroup.vue
@@ -328,5 +328,9 @@ td:has(table) {
 
 table tr[aria-current="location"] {
   background-color: var(--background-alt-blue-france-hover) !important;
+
+  button, :deep(button) { /* same pattern as in [numeroBio]/index.vue */
+    --hover-tint: var(--background-alt-blue-france-active);
+  }
 }
 </style>

--- a/src/components/widgets/ActionDropdown.vue
+++ b/src/components/widgets/ActionDropdown.vue
@@ -173,6 +173,8 @@ watch(show, (value) => {
     padding: 0.75rem !important;
     width: 100%;
     @extend .fr-btn--tertiary-no-outline;
+
+    --hover-tint: var(--background-default-grey-hover) !important;
   }
 }
 </style>

--- a/src/pages/exploitations/[numeroBio]/index.vue
+++ b/src/pages/exploitations/[numeroBio]/index.vue
@@ -83,15 +83,16 @@ meta:
     </p>
 
     <section v-for="{ year, records } in operatorStore.recordsByYear" :key="year" class="year-section fr-mt-4v">
-      <h2 class="fr-text--md year-row clickable" @click="showYears[year] = !showYears[year]">
+      <h2 class="fr-text--md year-row clickable" @click="showYears[year] = !showYears[year]" @keydown.enter="showYears[year] = !showYears[year]" tabindex="0" :aria-label="`Audit ${year}`" :aria-pressed="showYears[year]">
         <span
-            class="fr-icon"
-            :class="{ 'fr-icon-arrow-up-s-line': showYears[year], 'fr-icon-arrow-down-s-line': !showYears[year] }"
-            :aria-label="showYears[year] ? `Masquer les audits ${year}` : `Afficher les audits ${year}`"
-            aria-role="button"
+          class="fr-icon"
+          :class="{ 'fr-icon-arrow-up-s-line': showYears[year], 'fr-icon-arrow-down-s-line': !showYears[year] }"
         />Audit {{ year }}
       </h2>
-      <div class="fr-table fr-table--bordered fr-table--no-caption" :class="{ 'fr-sr-only': !showYears[year] }">
+
+      <button class="fr-btn fr-sr-only" v-text="showYears[year] ? `Masquer les versions de l'audit ${year}` : `Afficher les versions de l'audit ${year}`" />
+
+      <div class="fr-table fr-table--bordered fr-table--no-caption" v-if="showYears[year]" aria-live="assertive">
         <table :aria-describedby="`version-summary-${year}`">
           <caption>
             Versions du parcellaire pour l'audit {{ year }}
@@ -124,10 +125,11 @@ meta:
               class="version-row fr-enlarge-link"
               :class="{ 'version-row--disabled': !isOnline && !storage.records[record.record_id] }"
               role="link"
+              :aria-label="record.version_name"
           >
             <td></td>
             <th scope="row">
-              <router-link class="fr-text" :disabled="!isOnline && !storage.records[record.record_id]" :to="`/exploitations/${operatorStore.operator.numeroBio}/${record.record_id}`">
+              <router-link class="fr-text" :disabled="!isOnline && !storage.records[record.record_id]" :to="`/exploitations/${operatorStore.operator.numeroBio}/${record.record_id}`" :aria-label="record.version_name">
                 {{ record.version_name }}
               </router-link>
             </th>
@@ -145,7 +147,6 @@ meta:
                   v-if="storage.syncQueues[record.record_id]"
                   type="button"
                   class="fr-btn fr-btn--tertiary-no-outline fr-icon-refresh-line"
-                  title="Changements non-synchronisés"
                   disabled
               >Changements non-synchronisés</button>
               <button
@@ -153,16 +154,14 @@ meta:
                 type="button"
                 class="fr-btn fr-btn--tertiary-no-outline fr-icon-success-fill"
                 @click.stop.prevent="deleteDownloadModal = record.record_id"
-                title="Supprimer des téléchargements"
                 >Supprimer des téléchargements</button>
               <button
                 v-else
                 type="button"
                 class="fr-btn fr-btn--tertiary-no-outline fr-icon-download-line"
-                title="Télécharger en hors-ligne"
                 :disabled="!isOnline"
                 @click.stop.prevent="tryDownloadRecord(record.record_id)"
-                >Télécharger en hors-ligne</button>
+                >Télécharger pour un fonctionnement hors-ligne</button>
             </td>
             <td>
               <ActionDropdown with-icons :disabled="!isOnline">
@@ -428,5 +427,9 @@ tr.version-row--disabled:nth-child(2n) {
 
 tr.version-row:hover {
   background-color: var(--background-default-grey-hover);
+
+  button, :deep(button) {
+    --hover-tint: var(--background-default-grey-active);
+  }
 }
 </style>


### PR DESCRIPTION
Pour la liste des versions, et pour une version donnée.

J'ai aussi légèrement changé l'intitulé de la ligne de versions car ça prenait le condensé de *tout* le texte de la ligne. Désormais ça lit séquentiellement : 

1. nom de la version
2. télécharger pour une utilisation hors-ligne / supprimer des téléchargements
3. autres actions (si click, ⬇️)
  1. modifier les informations
  2. …