### PR TITLE
fix: fixe la version de sheetjs utilisée

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "vue-matomo": "^4.1.0",
         "vue-router": "^4.0.12",
         "vue3-toastify": "^0.1.11",
-        "xlsx": "git+https://git.sheetjs.com/sheetjs/sheetjs.git"
+        "xlsx": "git+https://git.sheetjs.com/sheetjs/sheetjs.git#2669c7c"
       },
       "devDependencies": {
         "@agencebio/cartobio-types": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "vue-matomo": "^4.1.0",
     "vue-router": "^4.0.12",
     "vue3-toastify": "^0.1.11",
-    "xlsx": "git+https://git.sheetjs.com/sheetjs/sheetjs.git"
+    "xlsx": "git+https://git.sheetjs.com/sheetjs/sheetjs.git#2669c7c"
   },
   "devDependencies": {
     "@agencebio/cartobio-types": "^1.6.1",


### PR DESCRIPTION
C'est mieux que de risquer de récupérer une version intermédiaire.

On aurait également pu utiliser la version tarball de cdn.sheetjs.com comme le préconise la documentation avec des versions fixes :
* https://docs.sheetjs.com/docs/getting-started/installation/nodejs/