### PR TITLE
a11y: corrige la vocalisation disjointe du République française

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -25,7 +25,7 @@
             <div class="fr-header__brand-top">
               <div class="fr-header__logo">
                 <p class="fr-logo">
-                  République<br>française
+                  République<br role="presentation">française
                 </p>
               </div>
 


### PR DESCRIPTION
En ajoutant l'attribut `role=presentation`, la vocalisation NVDA dira "République française" (en un seul morceau) plutôt que "République" (pause) "française" (en deux temps).