### PR TITLE
fix: cache l'onglet RPG

### DIFF
--- a/src/pages/exploitations/[numeroBio]/index.test.js
+++ b/src/pages/exploitations/[numeroBio]/index.test.js
@@ -56,4 +56,45 @@ describe("exploitations/:numeroBio", () => {
 
     expect(wrapper.findComponent(OperatorSetupFlow).exists()).toBe(true)
   })
+
+  it("RPG tab should be displayed for OC roles", async () => {
+    permissions.isOc = true
+    permissions.isAgri = false
+
+    const wrapper = mount(Page, {
+      props: {
+        numeroBio: '1234',
+      }
+    })
+
+    //
+    operatorStore.records = []
+    await flushPromises()
+
+    expect(wrapper.find("a[href='#from-source']").exists()).toBe(true)
+    const sources = wrapper.vm.operatorSetupActions?.find((e) => e.id ==='source')?.extraProps?.sources;
+    expect(sources).toBeTruthy()
+    expect(sources).toHaveLength(6)
+  })
+
+
+  it("RPG tab should not be displayed for agri roles", async () => {
+    permissions.isOc = false
+    permissions.isAgri = true
+
+    const wrapper = mount(Page, {
+      props: {
+        numeroBio: '1234',
+      }
+    })
+
+    //
+    operatorStore.records = []
+    await flushPromises()
+
+    expect(wrapper.find("a[href='#from-source']").exists()).toBe(true)
+    const sources = wrapper.vm.operatorSetupActions?.find((e) => e.id ==='source')?.extraProps?.sources;
+    expect(sources).toBeTruthy()
+    expect(sources).toHaveLength(5)
+  })
 })

--- a/src/pages/exploitations/[numeroBio]/index.vue
+++ b/src/pages/exploitations/[numeroBio]/index.vue
@@ -274,9 +274,9 @@ const operatorSetupActions = [
         sources.GEOFOLIA,
         sources.MESPARCELLES,
         sources.TELEPAC,
-        sources.RPG,
         sources.CVI,
-        sources.ANYGEO
+        sources.ANYGEO,
+        ...(permissions.isOc ? [sources.RPG] : []),
       ]
     }
   },


### PR DESCRIPTION
- limite l'affichage des l'onglet d'import RPG au organisme certificateur