### PR TITLE
feat: correctif watch parcelle

### DIFF
--- a/src/components/map/Layers/FeatureLayerOL.vue
+++ b/src/components/map/Layers/FeatureLayerOL.vue
@@ -574,7 +574,6 @@ watch(
 
     generateConversionLevelOverlays();
   },
-  { deep: true },
 );
 watch(
   () => record.record.record_id,


### PR DESCRIPTION
Undo redo permet pardois d'annuler l'affichage des parcelles